### PR TITLE
fix: Fixed trunk scaling issue

### DIFF
--- a/Body/AAUHuman/Scaling/DefaultAnthropometrics.any
+++ b/Body/AAUHuman/Scaling/DefaultAnthropometrics.any
@@ -63,7 +63,7 @@ AnyFolder SegmentDimensions = {
   #endif
   
   AnyVar HeadHeight ??= DesignVar(0.14*.BodyHeight/1.75); //height in neutral position from  C1HatNode to top of head
-  AnyVar TrunkHeight ??= DesignVar(0.620233*.BodyHeight/1.75); //height in neautral position from  C1HatNode to L5SacrumJnt
+  AnyVar TrunkHeight ??= DesignVar(0.6012695*.BodyHeight/1.75); //height in neautral position from  C1HatNode to L5SacrumJnt
   
   
   // These two folders are used by the scaling laws

--- a/Body/AAUHuman/Scaling/DefaultAnthropometrics_xyz.any
+++ b/Body/AAUHuman/Scaling/DefaultAnthropometrics_xyz.any
@@ -61,7 +61,7 @@ AnyFolder SegmentDimensions = {
   AnyVar HeadWidth ??= DesignVar(0.1797169*.SegmentScaleFactors.BodyScale); ///< Distance from the most lateral point to most medial point on the skull
   AnyVar HeadDepth ??= DesignVar(0.2295371*.SegmentScaleFactors.BodyScale); ///<  Distance from the most anterior point on the skull to the most posterior point on the skull
   
-  AnyVar TrunkHeight ??= DesignVar(0.606667*.BodyHeight/1.75); ///< Height in neutral position from  C1HatNode to L5SacrumJnt
+  AnyVar TrunkHeight ??= DesignVar(0.6012695*.BodyHeight/1.75); ///< Height in neutral position from  C1HatNode to L5SacrumJnt
   AnyVar TrunkWidth ??= DesignVar(0.3875729*.SegmentScaleFactors.BodyScale); //< Width between shoulder joints
   AnyVar TrunkDepth ??= DesignVar(0.1867059*.SegmentScaleFactors.BodyScale); ///< Horizontal distance between (midpoint of LTptT8S3Via3NodeL and LTptT8S3Via3NodeR) and (midpoint of RACP_CO6ViaNodeR and RACP_CO6ViaNodeL)
   

--- a/Body/AAUHuman/Trunk/TrunkData1.1/ThoracicNodes.any
+++ b/Body/AAUHuman/Trunk/TrunkData1.1/ThoracicNodes.any
@@ -5628,7 +5628,7 @@ AnyFolder Thorax = {
   AnyVar BodyMass = 75;  ///< This is a body mass that the trunk dataset is based on
 
   AnyVar UBHeight =  0.50; //Upperbody height
-  AnyVar Height = 0.620233;///< Height computed from the L5SacrumJnt to C1 node
+  AnyVar Height = vnorm( .C1.C1C0JntNode_pos - .L5.L5SacrumJntNode_pos);///< Height computed from the L5SacrumJnt to C1 node
   AnyVar Width = 0.3881839;///< Shoulder width
   AnyVar Depth = 0.1870;///< Horizontal distance between (midpoint of LTptT8S3Via3NodeL and LTptT8S3Via3NodeR) and (midpoint of RACP_CO6ViaNodeR and RACP_CO6ViaNodeL)
   


### PR DESCRIPTION
This corrects the fix in: 089792e23f7ad41a40553ba8f123c229e7c987da

@Hamedshayestehpour - I think the fix in 089792e23f was wrong. You shouldn't change the 'standard parameters', as this would change the height of the whole trunk. So, here I just changed the values used in the scaling laws so they have a same length as the 'standard parameter - Giving us a scaling factor of 1. 