### PR TITLE
fix: Renamed code macros and templates for spline muscles

### DIFF
--- a/Body/AAUHuman/BodyModels/GenericBodyModel/Spline.ClassTemplate.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/Spline.ClassTemplate.any
@@ -21,8 +21,8 @@
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -110,8 +110,8 @@ AnyFloat L=.Data_L ; //max(.S);
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -179,7 +179,7 @@ AnyFunInterpol Fun_Resample = {
   T = linspace(0.0,1.0,100);
   AnyFloat Temp = linspace(START+0.0,END+0.0,100);
   Data = .Fun_Resample_Ext(Temp)';
-  AnyFloat L=SPLINE_MUSLE_LENGTH(Data');
+  AnyFloat L=SPLINE_MUSCLE_POLY_LENGTH(Data');
 };  
 
 
@@ -188,7 +188,7 @@ AnyFunInterpol Fun_Resample_ABS = {
   AnyFloat test   = .Fun_Resample.T*.Fun_Resample.L;
   T= .Fun_Resample.T*.Fun_Resample.L;
   Data = .Fun_Resample.Data;
-  AnyFloat L=SPLINE_MUSLE_LENGTH(Data');
+  AnyFloat L=SPLINE_MUSCLE_POLY_LENGTH(Data');
 };  
 
  AnyVector a = linspace(0,1,NUM_ELEM);
@@ -235,8 +235,8 @@ AnyFunInterpol Fun_Resample_ABS = {
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -323,8 +323,8 @@ AnyFloat Points = Fun_Resample(a);
  AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/Spline.ClassTemplate.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/Spline.ClassTemplate.any
@@ -21,8 +21,8 @@
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(TRI(Data_Size-1)'));
+  AnyFloat Data_L = TOTAL_POLYLINE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -110,8 +110,8 @@ AnyFloat L=.Data_L ; //max(.S);
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(TRI(Data_Size-1)'));
+  AnyFloat Data_L = TOTAL_POLYLINE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -179,7 +179,7 @@ AnyFunInterpol Fun_Resample = {
   T = linspace(0.0,1.0,100);
   AnyFloat Temp = linspace(START+0.0,END+0.0,100);
   Data = .Fun_Resample_Ext(Temp)';
-  AnyFloat L=SPLINE_MUSCLE_POLY_LENGTH(Data');
+  AnyFloat L=TOTAL_POLYLINE_LENGTH(Data');
 };  
 
 
@@ -188,7 +188,7 @@ AnyFunInterpol Fun_Resample_ABS = {
   AnyFloat test   = .Fun_Resample.T*.Fun_Resample.L;
   T= .Fun_Resample.T*.Fun_Resample.L;
   Data = .Fun_Resample.Data;
-  AnyFloat L=SPLINE_MUSCLE_POLY_LENGTH(Data');
+  AnyFloat L=TOTAL_POLYLINE_LENGTH(Data');
 };  
 
  AnyVector a = linspace(0,1,NUM_ELEM);
@@ -235,8 +235,8 @@ AnyFunInterpol Fun_Resample_ABS = {
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(TRI(Data_Size-1)'));
+  AnyFloat Data_L = TOTAL_POLYLINE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -323,8 +323,8 @@ AnyFloat Points = Fun_Resample(a);
  AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSCLE_UPPER(Data_Size-1)));
-  AnyFloat Data_L = SPLINE_MUSCLE_POLY_LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(TRI(Data_Size-1)'));
+  AnyFloat Data_L = TOTAL_POLYLINE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/Spline.ClassTemplate.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/Spline.ClassTemplate.any
@@ -21,8 +21,8 @@
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(UPPER(Data_Size-1)));
-  AnyFloat Data_L = LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -110,8 +110,8 @@ AnyFloat L=.Data_L ; //max(.S);
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(UPPER(Data_Size-1)));
-  AnyFloat Data_L = LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -179,7 +179,7 @@ AnyFunInterpol Fun_Resample = {
   T = linspace(0.0,1.0,100);
   AnyFloat Temp = linspace(START+0.0,END+0.0,100);
   Data = .Fun_Resample_Ext(Temp)';
-  AnyFloat L=LENGTH(Data');
+  AnyFloat L=SPLINE_MUSLE_LENGTH(Data');
 };  
 
 
@@ -188,7 +188,7 @@ AnyFunInterpol Fun_Resample_ABS = {
   AnyFloat test   = .Fun_Resample.T*.Fun_Resample.L;
   T= .Fun_Resample.T*.Fun_Resample.L;
   Data = .Fun_Resample.Data;
-  AnyFloat L=LENGTH(Data');
+  AnyFloat L=SPLINE_MUSLE_LENGTH(Data');
 };  
 
  AnyVector a = linspace(0,1,NUM_ELEM);
@@ -235,8 +235,8 @@ AnyFunInterpol Fun_Resample_ABS = {
   AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(UPPER(Data_Size-1)));
-  AnyFloat Data_L = LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 
@@ -323,8 +323,8 @@ AnyFloat Points = Fun_Resample(a);
  AnyFloat Data=POINTS';
  
   AnyInt   Data_Size = SizesOf(Data')[0];
-  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(UPPER(Data_Size-1)));
-  AnyFloat Data_L = LENGTH(Data');
+  AnyFloat Data_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Data_Size))*Data')*(SPLINE_MUSLE_UPPER(Data_Size-1)));
+  AnyFloat Data_L = SPLINE_MUSLE_LENGTH(Data');
   AnyFloat Data_REL_L =  Data_Accum_L/Data_L;
 
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/SplineMuscle.ClassTemplate.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/SplineMuscle.ClassTemplate.any
@@ -1,6 +1,4 @@
-#define SPLINE_MUSCLE_UPPER(N) gteqfun(repmat(1,N, iarr(1, N))', repmat(1,N, iarr(1, N)))
-#define SPLINE_MUSCLE_POLY_LENGTH(P) sum(vnorm((arrcat(zeros(1,SizesOf(P)[0]-1), eye(SizesOf(P)[0]-1)')' - arrcat(eye(SizesOf(P)[0]-1)', zeros(1,SizesOf(P)[0]-1))')*P))
-  
+
 
 #class_template SplineMuscle_CreateElement (__CLASS__=AnyMuscleViaPoint, NAME1,NAME2){
       AnyRefNode &Org = .OriginSegment.NAME1##_Org.NAME2;
@@ -316,10 +314,10 @@
 
 AnyInt   Origin_Size = SizesOf(ORIGIN_POINTS)[0];
 AnyInt   Insertion_Size = SizesOf(INSERTION_POINTS)[0];
-AnyFloat Origin_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Origin_Size))*ORIGIN_POINTS)*(SPLINE_MUSCLE_UPPER(Origin_Size-1)));
-AnyFloat Insertion_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Insertion_Size))*INSERTION_POINTS)*(SPLINE_MUSCLE_UPPER(Insertion_Size-1)));
-AnyFloat Origin_L = SPLINE_MUSCLE_POLY_LENGTH(ORIGIN_POINTS);
-AnyFloat Insertion_L = SPLINE_MUSCLE_POLY_LENGTH(INSERTION_POINTS);
+AnyFloat Origin_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Origin_Size))*ORIGIN_POINTS)*(TRI(Origin_Size-1)'));
+AnyFloat Insertion_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Insertion_Size))*INSERTION_POINTS)*(TRI(Insertion_Size-1)'));
+AnyFloat Origin_L = TOTAL_POLYLINE_LENGTH(ORIGIN_POINTS);
+AnyFloat Insertion_L = TOTAL_POLYLINE_LENGTH(INSERTION_POINTS);
 AnyFloat Origin_REL_L =  Origin_Accum_L/Origin_L;
 AnyFloat Insertion_REL_L = Insertion_Accum_L/Insertion_L;
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/SplineMuscle.ClassTemplate.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/SplineMuscle.ClassTemplate.any
@@ -1,5 +1,5 @@
-#define SPLINE_MUSLE_UPPER(N) gteqfun(repmat(1,N, iarr(1, N))', repmat(1,N, iarr(1, N)))
-#define SPLINE_MUSLE_LENGTH(P) sum(vnorm((arrcat(zeros(1,SizesOf(P)[0]-1), eye(SizesOf(P)[0]-1)')' - arrcat(eye(SizesOf(P)[0]-1)', zeros(1,SizesOf(P)[0]-1))')*P))
+#define SPLINE_MUSCLE_UPPER(N) gteqfun(repmat(1,N, iarr(1, N))', repmat(1,N, iarr(1, N)))
+#define SPLINE_MUSCLE_POLY_LENGTH(P) sum(vnorm((arrcat(zeros(1,SizesOf(P)[0]-1), eye(SizesOf(P)[0]-1)')' - arrcat(eye(SizesOf(P)[0]-1)', zeros(1,SizesOf(P)[0]-1))')*P))
   
 
 #class_template SplineMuscle_CreateElement (__CLASS__=AnyMuscleViaPoint, NAME1,NAME2){
@@ -316,10 +316,10 @@
 
 AnyInt   Origin_Size = SizesOf(ORIGIN_POINTS)[0];
 AnyInt   Insertion_Size = SizesOf(INSERTION_POINTS)[0];
-AnyFloat Origin_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Origin_Size))*ORIGIN_POINTS)*(SPLINE_MUSLE_UPPER(Origin_Size-1)));
-AnyFloat Insertion_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Insertion_Size))*INSERTION_POINTS)*(SPLINE_MUSLE_UPPER(Insertion_Size-1)));
-AnyFloat Origin_L = SPLINE_MUSLE_LENGTH(ORIGIN_POINTS);
-AnyFloat Insertion_L = SPLINE_MUSLE_LENGTH(INSERTION_POINTS);
+AnyFloat Origin_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Origin_Size))*ORIGIN_POINTS)*(SPLINE_MUSCLE_UPPER(Origin_Size-1)));
+AnyFloat Insertion_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Insertion_Size))*INSERTION_POINTS)*(SPLINE_MUSCLE_UPPER(Insertion_Size-1)));
+AnyFloat Origin_L = SPLINE_MUSCLE_POLY_LENGTH(ORIGIN_POINTS);
+AnyFloat Insertion_L = SPLINE_MUSCLE_POLY_LENGTH(INSERTION_POINTS);
 AnyFloat Origin_REL_L =  Origin_Accum_L/Origin_L;
 AnyFloat Insertion_REL_L = Insertion_Accum_L/Insertion_L;
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/SplineMuscle.ClassTemplate.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/SplineMuscle.ClassTemplate.any
@@ -1,8 +1,8 @@
-#define UPPER(N) gteqfun(repmat(1,N, iarr(1, N))', repmat(1,N, iarr(1, N)))
-#define LENGTH(P) sum(vnorm((arrcat(zeros(1,SizesOf(P)[0]-1), eye(SizesOf(P)[0]-1)')' - arrcat(eye(SizesOf(P)[0]-1)', zeros(1,SizesOf(P)[0]-1))')*P))
+#define SPLINE_MUSLE_UPPER(N) gteqfun(repmat(1,N, iarr(1, N))', repmat(1,N, iarr(1, N)))
+#define SPLINE_MUSLE_LENGTH(P) sum(vnorm((arrcat(zeros(1,SizesOf(P)[0]-1), eye(SizesOf(P)[0]-1)')' - arrcat(eye(SizesOf(P)[0]-1)', zeros(1,SizesOf(P)[0]-1))')*P))
   
 
-#class_template CreateMuscleElement (__CLASS__=AnyMuscleViaPoint, NAME1,NAME2){
+#class_template SplineMuscle_CreateElement (__CLASS__=AnyMuscleViaPoint, NAME1,NAME2){
       AnyRefNode &Org = .OriginSegment.NAME1##_Org.NAME2;
       AnyRefNode &Ins = .InsertionSegment.NAME1##_Ins.NAME2;
       AnyMuscleModel MusMdl = {F0=..MuscleModel.F0/..NumberOfElements;Lf0=..MuscleModel.F0; Vol0=..MuscleModel.Vol0/..NumberOfElements;};
@@ -48,7 +48,7 @@
 
 
 
-#class_template Muscle_template_Simple(
+#class_template SplineMuscle_CreateMuscle(
   CREATE_ELEMENTS,
   AnyFolder &OriginSegment,
   ORIGIN_POINTS,
@@ -103,121 +103,121 @@
   };
   
   #if CREATE_ELEMENTS >= 1 
-    CreateMuscleElement elem1 (NAME1=__NAME__,NAME2=Node0)= {};
+    SplineMuscle_CreateElement elem1 (NAME1=__NAME__,NAME2=Node0)= {};
   #endif
   #if CREATE_ELEMENTS >= 2
-    CreateMuscleElement elem2 (NAME1=__NAME__,NAME2=Node1)= {};
+    SplineMuscle_CreateElement elem2 (NAME1=__NAME__,NAME2=Node1)= {};
   #endif
   #if CREATE_ELEMENTS >= 3
-    CreateMuscleElement elem3 (NAME1=__NAME__,NAME2=Node2)= {};
+    SplineMuscle_CreateElement elem3 (NAME1=__NAME__,NAME2=Node2)= {};
   #endif
   #if CREATE_ELEMENTS  >= 4 
-    CreateMuscleElement elem4 (NAME1=__NAME__,NAME2=Node3)= {};
+    SplineMuscle_CreateElement elem4 (NAME1=__NAME__,NAME2=Node3)= {};
   #endif
   #if CREATE_ELEMENTS  >= 5
-    CreateMuscleElement elem5 (NAME1=__NAME__,NAME2=Node4)= {};
+    SplineMuscle_CreateElement elem5 (NAME1=__NAME__,NAME2=Node4)= {};
   #endif
   #if CREATE_ELEMENTS  >= 6
-    CreateMuscleElement elem6 (NAME1=__NAME__,NAME2=Node5)= {};
+    SplineMuscle_CreateElement elem6 (NAME1=__NAME__,NAME2=Node5)= {};
   #endif
   #if CREATE_ELEMENTS  >= 7
-    CreateMuscleElement elem7 (NAME1=__NAME__,NAME2=Node6)= {};
+    SplineMuscle_CreateElement elem7 (NAME1=__NAME__,NAME2=Node6)= {};
   #endif
   #if CREATE_ELEMENTS  >= 8 
-    CreateMuscleElement elem8 (NAME1=__NAME__,NAME2=Node7)= {};
+    SplineMuscle_CreateElement elem8 (NAME1=__NAME__,NAME2=Node7)= {};
   #endif
   #if CREATE_ELEMENTS  >= 9 
-    CreateMuscleElement elem9 (NAME1=__NAME__,NAME2=Node8)= {};
+    SplineMuscle_CreateElement elem9 (NAME1=__NAME__,NAME2=Node8)= {};
   #endif
   #if CREATE_ELEMENTS  >= 10
-     CreateMuscleElement elem10 (NAME1=__NAME__,NAME2=Node9)= {};
+     SplineMuscle_CreateElement elem10 (NAME1=__NAME__,NAME2=Node9)= {};
   #endif
   #if CREATE_ELEMENTS  >= 11 
-     CreateMuscleElement elem11 (NAME1=__NAME__,NAME2=Node10)= {};
+     SplineMuscle_CreateElement elem11 (NAME1=__NAME__,NAME2=Node10)= {};
   #endif
   #if CREATE_ELEMENTS  >= 12 
-     CreateMuscleElement elem12 (NAME1=__NAME__,NAME2=Node11)= {};
+     SplineMuscle_CreateElement elem12 (NAME1=__NAME__,NAME2=Node11)= {};
   #endif
   #if CREATE_ELEMENTS  >= 13
-     CreateMuscleElement elem13 (NAME1=__NAME__,NAME2=Node12)= {};
+     SplineMuscle_CreateElement elem13 (NAME1=__NAME__,NAME2=Node12)= {};
   #endif
   #if CREATE_ELEMENTS  >= 14 
-     CreateMuscleElement elem14 (NAME1=__NAME__,NAME2=Node13)= {};
+     SplineMuscle_CreateElement elem14 (NAME1=__NAME__,NAME2=Node13)= {};
   #endif
   #if CREATE_ELEMENTS  >= 15 
-     CreateMuscleElement elem15 (NAME1=__NAME__,NAME2=Node14)= {};
+     SplineMuscle_CreateElement elem15 (NAME1=__NAME__,NAME2=Node14)= {};
   #endif
   #if CREATE_ELEMENTS  >= 16 
-     CreateMuscleElement elem16 (NAME1=__NAME__,NAME2=Node15)= {};
+     SplineMuscle_CreateElement elem16 (NAME1=__NAME__,NAME2=Node15)= {};
   #endif
   #if CREATE_ELEMENTS  >= 17
-     CreateMuscleElement elem17 (NAME1=__NAME__,NAME2=Node16)= {};
+     SplineMuscle_CreateElement elem17 (NAME1=__NAME__,NAME2=Node16)= {};
   #endif
   #if CREATE_ELEMENTS  >= 18 
-     CreateMuscleElement elem18 (NAME1=__NAME__,NAME2=Node17)= {};
+     SplineMuscle_CreateElement elem18 (NAME1=__NAME__,NAME2=Node17)= {};
   #endif
   #if CREATE_ELEMENTS  >= 19
-     CreateMuscleElement elem19 (NAME1=__NAME__,NAME2=Node18)= {};
+     SplineMuscle_CreateElement elem19 (NAME1=__NAME__,NAME2=Node18)= {};
   #endif
   #if CREATE_ELEMENTS  >= 20
-     CreateMuscleElement elem20 (NAME1=__NAME__,NAME2=Node19)= {};
+     SplineMuscle_CreateElement elem20 (NAME1=__NAME__,NAME2=Node19)= {};
   #endif
    #if CREATE_ELEMENTS  >= 21
-     CreateMuscleElement elem21 (NAME1=__NAME__,NAME2=Node20)= {};
+     SplineMuscle_CreateElement elem21 (NAME1=__NAME__,NAME2=Node20)= {};
   #endif
   #if CREATE_ELEMENTS  >= 22
-     CreateMuscleElement elem22 (NAME1=__NAME__,NAME2=Node21)= {};
+     SplineMuscle_CreateElement elem22 (NAME1=__NAME__,NAME2=Node21)= {};
   #endif
   #if CREATE_ELEMENTS  >= 23
-     CreateMuscleElement elem23 (NAME1=__NAME__,NAME2=Node22)= {};
+     SplineMuscle_CreateElement elem23 (NAME1=__NAME__,NAME2=Node22)= {};
   #endif
   #if CREATE_ELEMENTS  >= 24
-     CreateMuscleElement elem24 (NAME1=__NAME__,NAME2=Node23)= {};
+     SplineMuscle_CreateElement elem24 (NAME1=__NAME__,NAME2=Node23)= {};
   #endif
   #if CREATE_ELEMENTS  >= 25
-     CreateMuscleElement elem25 (NAME1=__NAME__,NAME2=Node24)= {};
+     SplineMuscle_CreateElement elem25 (NAME1=__NAME__,NAME2=Node24)= {};
   #endif
   #if CREATE_ELEMENTS  >= 26
-     CreateMuscleElement elem26 (NAME1=__NAME__,NAME2=Node25)= {};
+     SplineMuscle_CreateElement elem26 (NAME1=__NAME__,NAME2=Node25)= {};
   #endif
   #if CREATE_ELEMENTS  >= 27
-     CreateMuscleElement elem27 (NAME1=__NAME__,NAME2=Node26)= {};
+     SplineMuscle_CreateElement elem27 (NAME1=__NAME__,NAME2=Node26)= {};
   #endif
   #if CREATE_ELEMENTS  >= 28
-     CreateMuscleElement elem28 (NAME1=__NAME__,NAME2=Node27)= {};
+     SplineMuscle_CreateElement elem28 (NAME1=__NAME__,NAME2=Node27)= {};
   #endif
   #if CREATE_ELEMENTS  >= 29
-     CreateMuscleElement elem29 (NAME1=__NAME__,NAME2=Node28)= {};
+     SplineMuscle_CreateElement elem29 (NAME1=__NAME__,NAME2=Node28)= {};
   #endif
   #if CREATE_ELEMENTS  >= 30
-     CreateMuscleElement elem30 (NAME1=__NAME__,NAME2=Node29)= {};
+     SplineMuscle_CreateElement elem30 (NAME1=__NAME__,NAME2=Node29)= {};
   #endif
   #if CREATE_ELEMENTS  >= 31
-     CreateMuscleElement elem31 (NAME1=__NAME__,NAME2=Node30)= {};
+     SplineMuscle_CreateElement elem31 (NAME1=__NAME__,NAME2=Node30)= {};
   #endif
   #if CREATE_ELEMENTS  >= 32
-     CreateMuscleElement elem32 (NAME1=__NAME__,NAME2=Node31)= {};
+     SplineMuscle_CreateElement elem32 (NAME1=__NAME__,NAME2=Node31)= {};
   #endif
   #if CREATE_ELEMENTS  >= 33
-     CreateMuscleElement elem33 (NAME1=__NAME__,NAME2=Node32)= {};
+     SplineMuscle_CreateElement elem33 (NAME1=__NAME__,NAME2=Node32)= {};
   #endif
   #if CREATE_ELEMENTS  >= 34
-     CreateMuscleElement elem34 (NAME1=__NAME__,NAME2=Node33)= {};
+     SplineMuscle_CreateElement elem34 (NAME1=__NAME__,NAME2=Node33)= {};
   #endif
   #if CREATE_ELEMENTS  >= 35
-     CreateMuscleElement elem35 (NAME1=__NAME__,NAME2=Node34)= {};
+     SplineMuscle_CreateElement elem35 (NAME1=__NAME__,NAME2=Node34)= {};
   #endif
   #if CREATE_ELEMENTS  >= 36
-     CreateMuscleElement elem36 (NAME1=__NAME__,NAME2=Node35)= {};
+     SplineMuscle_CreateElement elem36 (NAME1=__NAME__,NAME2=Node35)= {};
   #endif
   #if CREATE_ELEMENTS  >= 37
-     CreateMuscleElement elem37 (NAME1=__NAME__,NAME2=Node36)= {};
+     SplineMuscle_CreateElement elem37 (NAME1=__NAME__,NAME2=Node36)= {};
   #endif
   #if CREATE_ELEMENTS  >= 38
-     CreateMuscleElement elem38 (NAME1=__NAME__,NAME2=Node37)= {};
+     SplineMuscle_CreateElement elem38 (NAME1=__NAME__,NAME2=Node37)= {};
   #endif
   #if CREATE_ELEMENTS  >= 39
-     CreateMuscleElement elem39 (NAME1=__NAME__,NAME2=Node38)= {};
+     SplineMuscle_CreateElement elem39 (NAME1=__NAME__,NAME2=Node38)= {};
   #endif
   
 
@@ -232,7 +232,7 @@
 //C is a point on the insertion spline.
 //the input to the calculation is a  desired angle, a set of parameters values and two spline functions
 //the spline functions 
-#define OFFSET(DesiredAngle, par,InsertionFun,OriginFun) \
+#define SPLINE_MUSLE_OFFSET(DesiredAngle, par,InsertionFun,OriginFun) \
   AnyFolder Offsets = { \
   //small pertubation
   AnyVar Pert = 0.001;\
@@ -275,7 +275,7 @@
 
 
 
-#class_template Muscle_template_Simple_Angle_MultiOffset(
+#class_template SplineMuscle_CreateMuscleMultiOffset(
   CREATE_ELEMENTS,
   AnyFolder &OriginSegment,
   ORIGIN_POINTS,
@@ -316,10 +316,10 @@
 
 AnyInt   Origin_Size = SizesOf(ORIGIN_POINTS)[0];
 AnyInt   Insertion_Size = SizesOf(INSERTION_POINTS)[0];
-AnyFloat Origin_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Origin_Size))*ORIGIN_POINTS)*(UPPER(Origin_Size-1)));
-AnyFloat Insertion_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Insertion_Size))*INSERTION_POINTS)*(UPPER(Insertion_Size-1)));
-AnyFloat Origin_L = LENGTH(ORIGIN_POINTS);
-AnyFloat Insertion_L = LENGTH(INSERTION_POINTS);
+AnyFloat Origin_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Origin_Size))*ORIGIN_POINTS)*(SPLINE_MUSLE_UPPER(Origin_Size-1)));
+AnyFloat Insertion_Accum_L = arrcat(0.0,vnorm((DIFFMAT(Insertion_Size))*INSERTION_POINTS)*(SPLINE_MUSLE_UPPER(Insertion_Size-1)));
+AnyFloat Origin_L = SPLINE_MUSLE_LENGTH(ORIGIN_POINTS);
+AnyFloat Insertion_L = SPLINE_MUSLE_LENGTH(INSERTION_POINTS);
 AnyFloat Origin_REL_L =  Origin_Accum_L/Origin_L;
 AnyFloat Insertion_REL_L = Insertion_Accum_L/Insertion_L;
 
@@ -377,7 +377,7 @@ AnyFunInterpol Fun_Insertion_Extend = {
 };  
 
 //calculate offsets 
-OFFSET(.DesiredAngle,.Origin_REL_L,Fun_Insertion_Extend,Fun_Origin_Extend)
+SPLINE_MUSLE_OFFSET(.DesiredAngle,.Origin_REL_L,Fun_Insertion_Extend,Fun_Origin_Extend)
 
 //Make interpolated offset function
 AnyFunInterpol InsertionFun_Offset = { 
@@ -425,121 +425,121 @@ AnyVector a_org = linspace(iffun(ltfun(min_,0),-min_+0.01,0.0),iffun(gtfun(max_,
   
   
    #if CREATE_ELEMENTS >= 1 
-    CreateMuscleElement elem1 (NAME1=__NAME__,NAME2=Node0)= {};
+    SplineMuscle_CreateElement elem1 (NAME1=__NAME__,NAME2=Node0)= {};
   #endif
   #if CREATE_ELEMENTS >= 2
-    CreateMuscleElement elem2 (NAME1=__NAME__,NAME2=Node1)= {};
+    SplineMuscle_CreateElement elem2 (NAME1=__NAME__,NAME2=Node1)= {};
   #endif
   #if CREATE_ELEMENTS >= 3
-    CreateMuscleElement elem3 (NAME1=__NAME__,NAME2=Node2)= {};
+    SplineMuscle_CreateElement elem3 (NAME1=__NAME__,NAME2=Node2)= {};
   #endif
   #if CREATE_ELEMENTS  >= 4 
-    CreateMuscleElement elem4 (NAME1=__NAME__,NAME2=Node3)= {};
+    SplineMuscle_CreateElement elem4 (NAME1=__NAME__,NAME2=Node3)= {};
   #endif
   #if CREATE_ELEMENTS  >= 5
-    CreateMuscleElement elem5 (NAME1=__NAME__,NAME2=Node4)= {};
+    SplineMuscle_CreateElement elem5 (NAME1=__NAME__,NAME2=Node4)= {};
   #endif
   #if CREATE_ELEMENTS  >= 6
-    CreateMuscleElement elem6 (NAME1=__NAME__,NAME2=Node5)= {};
+    SplineMuscle_CreateElement elem6 (NAME1=__NAME__,NAME2=Node5)= {};
   #endif
   #if CREATE_ELEMENTS  >= 7
-    CreateMuscleElement elem7 (NAME1=__NAME__,NAME2=Node6)= {};
+    SplineMuscle_CreateElement elem7 (NAME1=__NAME__,NAME2=Node6)= {};
   #endif
   #if CREATE_ELEMENTS  >= 8 
-    CreateMuscleElement elem8 (NAME1=__NAME__,NAME2=Node7)= {};
+    SplineMuscle_CreateElement elem8 (NAME1=__NAME__,NAME2=Node7)= {};
   #endif
   #if CREATE_ELEMENTS  >= 9 
-    CreateMuscleElement elem9 (NAME1=__NAME__,NAME2=Node8)= {};
+    SplineMuscle_CreateElement elem9 (NAME1=__NAME__,NAME2=Node8)= {};
   #endif
   #if CREATE_ELEMENTS  >= 10
-     CreateMuscleElement elem10 (NAME1=__NAME__,NAME2=Node9)= {};
+     SplineMuscle_CreateElement elem10 (NAME1=__NAME__,NAME2=Node9)= {};
   #endif
   #if CREATE_ELEMENTS  >= 11 
-     CreateMuscleElement elem11 (NAME1=__NAME__,NAME2=Node10)= {};
+     SplineMuscle_CreateElement elem11 (NAME1=__NAME__,NAME2=Node10)= {};
   #endif
   #if CREATE_ELEMENTS  >= 12 
-     CreateMuscleElement elem12 (NAME1=__NAME__,NAME2=Node11)= {};
+     SplineMuscle_CreateElement elem12 (NAME1=__NAME__,NAME2=Node11)= {};
   #endif
   #if CREATE_ELEMENTS  >= 13
-     CreateMuscleElement elem13 (NAME1=__NAME__,NAME2=Node12)= {};
+     SplineMuscle_CreateElement elem13 (NAME1=__NAME__,NAME2=Node12)= {};
   #endif
   #if CREATE_ELEMENTS  >= 14 
-     CreateMuscleElement elem14 (NAME1=__NAME__,NAME2=Node13)= {};
+     SplineMuscle_CreateElement elem14 (NAME1=__NAME__,NAME2=Node13)= {};
   #endif
   #if CREATE_ELEMENTS  >= 15 
-     CreateMuscleElement elem15 (NAME1=__NAME__,NAME2=Node14)= {};
+     SplineMuscle_CreateElement elem15 (NAME1=__NAME__,NAME2=Node14)= {};
   #endif
   #if CREATE_ELEMENTS  >= 16 
-     CreateMuscleElement elem16 (NAME1=__NAME__,NAME2=Node15)= {};
+     SplineMuscle_CreateElement elem16 (NAME1=__NAME__,NAME2=Node15)= {};
   #endif
   #if CREATE_ELEMENTS  >= 17
-     CreateMuscleElement elem17 (NAME1=__NAME__,NAME2=Node16)= {};
+     SplineMuscle_CreateElement elem17 (NAME1=__NAME__,NAME2=Node16)= {};
   #endif
   #if CREATE_ELEMENTS  >= 18 
-     CreateMuscleElement elem18 (NAME1=__NAME__,NAME2=Node17)= {};
+     SplineMuscle_CreateElement elem18 (NAME1=__NAME__,NAME2=Node17)= {};
   #endif
   #if CREATE_ELEMENTS  >= 19
-     CreateMuscleElement elem19 (NAME1=__NAME__,NAME2=Node18)= {};
+     SplineMuscle_CreateElement elem19 (NAME1=__NAME__,NAME2=Node18)= {};
   #endif
   #if CREATE_ELEMENTS  >= 20
-     CreateMuscleElement elem20 (NAME1=__NAME__,NAME2=Node19)= {};
+     SplineMuscle_CreateElement elem20 (NAME1=__NAME__,NAME2=Node19)= {};
   #endif
    #if CREATE_ELEMENTS  >= 21
-     CreateMuscleElement elem21 (NAME1=__NAME__,NAME2=Node20)= {};
+     SplineMuscle_CreateElement elem21 (NAME1=__NAME__,NAME2=Node20)= {};
   #endif
   #if CREATE_ELEMENTS  >= 22
-     CreateMuscleElement elem22 (NAME1=__NAME__,NAME2=Node21)= {};
+     SplineMuscle_CreateElement elem22 (NAME1=__NAME__,NAME2=Node21)= {};
   #endif
   #if CREATE_ELEMENTS  >= 23
-     CreateMuscleElement elem23 (NAME1=__NAME__,NAME2=Node22)= {};
+     SplineMuscle_CreateElement elem23 (NAME1=__NAME__,NAME2=Node22)= {};
   #endif
   #if CREATE_ELEMENTS  >= 24
-     CreateMuscleElement elem24 (NAME1=__NAME__,NAME2=Node23)= {};
+     SplineMuscle_CreateElement elem24 (NAME1=__NAME__,NAME2=Node23)= {};
   #endif
   #if CREATE_ELEMENTS  >= 25
-     CreateMuscleElement elem25 (NAME1=__NAME__,NAME2=Node24)= {};
+     SplineMuscle_CreateElement elem25 (NAME1=__NAME__,NAME2=Node24)= {};
   #endif
   #if CREATE_ELEMENTS  >= 26
-     CreateMuscleElement elem26 (NAME1=__NAME__,NAME2=Node25)= {};
+     SplineMuscle_CreateElement elem26 (NAME1=__NAME__,NAME2=Node25)= {};
   #endif
   #if CREATE_ELEMENTS  >= 27
-     CreateMuscleElement elem27 (NAME1=__NAME__,NAME2=Node26)= {};
+     SplineMuscle_CreateElement elem27 (NAME1=__NAME__,NAME2=Node26)= {};
   #endif
   #if CREATE_ELEMENTS  >= 28
-     CreateMuscleElement elem28 (NAME1=__NAME__,NAME2=Node27)= {};
+     SplineMuscle_CreateElement elem28 (NAME1=__NAME__,NAME2=Node27)= {};
   #endif
   #if CREATE_ELEMENTS  >= 29
-     CreateMuscleElement elem29 (NAME1=__NAME__,NAME2=Node28)= {};
+     SplineMuscle_CreateElement elem29 (NAME1=__NAME__,NAME2=Node28)= {};
   #endif
   #if CREATE_ELEMENTS  >= 30
-     CreateMuscleElement elem30 (NAME1=__NAME__,NAME2=Node29)= {};
+     SplineMuscle_CreateElement elem30 (NAME1=__NAME__,NAME2=Node29)= {};
   #endif
   #if CREATE_ELEMENTS  >= 31
-     CreateMuscleElement elem31 (NAME1=__NAME__,NAME2=Node30)= {};
+     SplineMuscle_CreateElement elem31 (NAME1=__NAME__,NAME2=Node30)= {};
   #endif
   #if CREATE_ELEMENTS  >= 32
-     CreateMuscleElement elem32 (NAME1=__NAME__,NAME2=Node31)= {};
+     SplineMuscle_CreateElement elem32 (NAME1=__NAME__,NAME2=Node31)= {};
   #endif
   #if CREATE_ELEMENTS  >= 33
-     CreateMuscleElement elem33 (NAME1=__NAME__,NAME2=Node32)= {};
+     SplineMuscle_CreateElement elem33 (NAME1=__NAME__,NAME2=Node32)= {};
   #endif
   #if CREATE_ELEMENTS  >= 34
-     CreateMuscleElement elem34 (NAME1=__NAME__,NAME2=Node33)= {};
+     SplineMuscle_CreateElement elem34 (NAME1=__NAME__,NAME2=Node33)= {};
   #endif
   #if CREATE_ELEMENTS  >= 35
-     CreateMuscleElement elem35 (NAME1=__NAME__,NAME2=Node34)= {};
+     SplineMuscle_CreateElement elem35 (NAME1=__NAME__,NAME2=Node34)= {};
   #endif
   #if CREATE_ELEMENTS  >= 36
-     CreateMuscleElement elem36 (NAME1=__NAME__,NAME2=Node35)= {};
+     SplineMuscle_CreateElement elem36 (NAME1=__NAME__,NAME2=Node35)= {};
   #endif
   #if CREATE_ELEMENTS  >= 37
-     CreateMuscleElement elem37 (NAME1=__NAME__,NAME2=Node36)= {};
+     SplineMuscle_CreateElement elem37 (NAME1=__NAME__,NAME2=Node36)= {};
   #endif
   #if CREATE_ELEMENTS  >= 38
-     CreateMuscleElement elem38 (NAME1=__NAME__,NAME2=Node37)= {};
+     SplineMuscle_CreateElement elem38 (NAME1=__NAME__,NAME2=Node37)= {};
   #endif
   #if CREATE_ELEMENTS  >= 39
-     CreateMuscleElement elem39 (NAME1=__NAME__,NAME2=Node38)= {};
+     SplineMuscle_CreateElement elem39 (NAME1=__NAME__,NAME2=Node38)= {};
   #endif
   
    

--- a/Body/AAUHuman/Trunk/MusclesLeft.any
+++ b/Body/AAUHuman/Trunk/MusclesLeft.any
@@ -1013,7 +1013,7 @@ AnyFolder ErectorSpinae = {
 
 AnyFolder InterCostalisExternal = 
   {
-    Muscle_template_Simple IC_Ext_R1R2(
+    SplineMuscle_CreateMuscle IC_Ext_R1R2(
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Left.R1Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R1.Left.IC_R1_Ext_Inf.Points,
@@ -1022,7 +1022,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R1R2
     )={};
     
-    Muscle_template_Simple IC_Ext_R2R3 (
+    SplineMuscle_CreateMuscle IC_Ext_R2R3 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R2Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R2.Left.IC_R2_Ext_Inf.Points,
@@ -1031,7 +1031,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R2R3
     )={};
     
-    Muscle_template_Simple IC_Ext_R3R4 (
+    SplineMuscle_CreateMuscle IC_Ext_R3R4 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R3Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R3.Left.IC_R3_Ext_Inf.Points,
@@ -1040,7 +1040,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R3R4
     )={};
     
-    Muscle_template_Simple IC_Ext_R4R5 (
+    SplineMuscle_CreateMuscle IC_Ext_R4R5 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R4Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R4.Left.IC_R4_Ext_Inf.Points,
@@ -1049,7 +1049,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R4R5
     )={};
         
-    Muscle_template_Simple IC_Ext_R5R6 (
+    SplineMuscle_CreateMuscle IC_Ext_R5R6 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R5Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R5.Left.IC_R5_Ext_Inf.Points,
@@ -1058,7 +1058,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R5R6
     )={};
     
-    Muscle_template_Simple IC_Ext_R6R7 (
+    SplineMuscle_CreateMuscle IC_Ext_R6R7 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R6Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R6.Left.IC_R6_Ext_Inf.Points,
@@ -1067,7 +1067,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R6R7
     )={};
         
-    Muscle_template_Simple IC_Ext_R7R8 (
+    SplineMuscle_CreateMuscle IC_Ext_R7R8 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R7Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R7.Left.IC_R7_Ext_Inf.Points,
@@ -1076,7 +1076,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R7R8
     )={};
     
-    Muscle_template_Simple IC_Ext_R8R9 (
+    SplineMuscle_CreateMuscle IC_Ext_R8R9 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R8Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R8.Left.IC_R8_Ext_Inf.Points,
@@ -1085,7 +1085,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R8R9
     )={};
           
-    Muscle_template_Simple IC_Ext_R9R10 (
+    SplineMuscle_CreateMuscle IC_Ext_R9R10 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R9Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R9.Left.IC_R9_Ext_Inf.Points,
@@ -1094,7 +1094,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R9R10
     )={};
       
-    Muscle_template_Simple IC_Ext_R10R11 (
+    SplineMuscle_CreateMuscle IC_Ext_R10R11 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Left.R10Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R10.Left.IC_R10_Ext_Inf.Points,
@@ -1103,7 +1103,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R10R11
     )={};
     
-    Muscle_template_Simple IC_Ext_R11R12 (
+    SplineMuscle_CreateMuscle IC_Ext_R11R12 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-2),
       OriginSegment=....Segments.Left.R11Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R11.Left.IC_R11_Ext_Inf.Points,
@@ -1117,7 +1117,7 @@ AnyFolder InterCostalisExternal =
   {
   
   
-    Muscle_template_Simple IC_Int_R1R2 (
+    SplineMuscle_CreateMuscle IC_Int_R1R2 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Left.R1Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R1.Left.IC_R1_Int_Inf.Points,
@@ -1143,7 +1143,7 @@ AnyFolder InterCostalisExternal =
     
 
     
-    Muscle_template_Simple IC_Int_R2R3 (
+    SplineMuscle_CreateMuscle IC_Int_R2R3 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R2Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R2.Left.IC_R2_Int_Inf.Points,
@@ -1166,7 +1166,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
         
-    Muscle_template_Simple IC_Int_R3R4 (
+    SplineMuscle_CreateMuscle IC_Int_R3R4 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R3Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R3.Left.IC_R3_Int_Inf.Points,
@@ -1189,7 +1189,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
         
-    Muscle_template_Simple IC_Int_R4R5 (
+    SplineMuscle_CreateMuscle IC_Int_R4R5 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
     OriginSegment=....Segments.Left.R4Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R4.Left.IC_R4_Int_Inf.Points,
@@ -1212,7 +1212,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
     
-    Muscle_template_Simple IC_Int_R5R6 (
+    SplineMuscle_CreateMuscle IC_Int_R5R6 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R5Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R5.Left.IC_R5_Int_Inf.Points,
@@ -1235,7 +1235,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
       
-    Muscle_template_Simple IC_Int_R6R7 (
+    SplineMuscle_CreateMuscle IC_Int_R6R7 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R6Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R6.Left.IC_R6_Int_Inf.Points,
@@ -1258,7 +1258,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
     
-    Muscle_template_Simple IC_Int_R7R8 (
+    SplineMuscle_CreateMuscle IC_Int_R7R8 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R7Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R7.Left.IC_R7_Int_Inf.Points,
@@ -1285,7 +1285,7 @@ AnyFolder InterCostalisExternal =
       };
     };
       
-    Muscle_template_Simple IC_Int_R8R9 (
+    SplineMuscle_CreateMuscle IC_Int_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R8Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R8.Left.IC_R8_Int_Inf.Points,
@@ -1310,7 +1310,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
         
-    Muscle_template_Simple IC_Int_R9R10 (
+    SplineMuscle_CreateMuscle IC_Int_R9R10 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R9Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R9.Left.IC_R9_Int_Inf.Points,
@@ -1335,7 +1335,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
     
-    Muscle_template_Simple IC_Int_R10R11 (
+    SplineMuscle_CreateMuscle IC_Int_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
         OriginSegment=....Segments.Left.R10Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R10.Left.IC_R10_Int_Inf.Points,
@@ -1344,7 +1344,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisInternal.IC_Int_R10R11
     )={};
         
-    Muscle_template_Simple IC_Int_R11R12 (
+    SplineMuscle_CreateMuscle IC_Int_R11R12 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-1),
         OriginSegment=....Segments.Left.R11Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R11.Left.IC_R11_Int_Inf.Points,
@@ -1363,7 +1363,7 @@ AnyFolder InterCostalisExternal =
   AnyFolder InnermostInterCostalis = 
   {
 
-    Muscle_template_Simple IC_Inn_R1R2(
+    SplineMuscle_CreateMuscle IC_Inn_R1R2(
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
         OriginSegment=....Segments.Left.R1Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R1.Left.IC_R1_Inn_Inf.Points,
@@ -1372,7 +1372,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R1R2
     )={};
     
-    Muscle_template_Simple IC_Inn_R2R3 (
+    SplineMuscle_CreateMuscle IC_Inn_R2R3 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R2Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R2.Left.IC_R2_Inn_Inf.Points,
@@ -1381,7 +1381,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R2R3
     )={};
     
-    Muscle_template_Simple IC_Inn_R3R4 (
+    SplineMuscle_CreateMuscle IC_Inn_R3R4 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R3Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R3.Left.IC_R3_Inn_Inf.Points,
@@ -1390,7 +1390,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R3R4
     )={};
     
-    Muscle_template_Simple IC_Inn_R4R5 (
+    SplineMuscle_CreateMuscle IC_Inn_R4R5 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R4Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R4.Left.IC_R4_Inn_Inf.Points,
@@ -1399,7 +1399,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R4R5
     )={};
         
-    Muscle_template_Simple IC_Inn_R5R6 (
+    SplineMuscle_CreateMuscle IC_Inn_R5R6 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R5Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R5.Left.IC_R5_Inn_Inf.Points,
@@ -1408,7 +1408,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R5R6
     )={};
     
-    Muscle_template_Simple IC_Inn_R6R7 (
+    SplineMuscle_CreateMuscle IC_Inn_R6R7 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R6Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R6.Left.IC_R6_Inn_Inf.Points,
@@ -1417,7 +1417,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R6R7
     )={};
         
-    Muscle_template_Simple IC_Inn_R7R8 (
+    SplineMuscle_CreateMuscle IC_Inn_R7R8 (
         CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R7Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R7.Left.IC_R7_Inn_Inf.Points,
@@ -1426,7 +1426,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R7R8
     )={};
     
-    Muscle_template_Simple IC_Inn_R8R9 (
+    SplineMuscle_CreateMuscle IC_Inn_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R8Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R8.Left.IC_R8_Inn_Inf.Points,
@@ -1435,7 +1435,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R8R9
     )={};
           
-    Muscle_template_Simple IC_Inn_R9R10 (
+    SplineMuscle_CreateMuscle IC_Inn_R9R10 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Left.R9Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R9.Left.IC_R9_Inn_Inf.Points,
@@ -1444,7 +1444,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R9R10
     )={};
       
-    Muscle_template_Simple IC_Inn_R10R11 (
+    SplineMuscle_CreateMuscle IC_Inn_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
         OriginSegment=....Segments.Left.R10Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R10.Left.IC_R10_Inn_Inf.Points,
@@ -1453,7 +1453,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R10R11
     )={};
     
-    Muscle_template_Simple IC_Inn_R11R12 (
+    SplineMuscle_CreateMuscle IC_Inn_R11R12 (
         CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-2),
         OriginSegment=....Segments.Left.R11Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R11.Left.IC_R11_Inn_Inf.Points,
@@ -1485,7 +1485,7 @@ AnyFolder InterCostalisExternal =
   
     
     
- Muscle_template_Simple_Angle_MultiOffset IC_Inn_R1R2 (
+ SplineMuscle_CreateMuscleMultiOffset IC_Inn_R1R2 (
       CREATE_ELEMENTS= IC_MULTIPLIER*IC_SIZE,
       OriginSegment=....Segments.Left.R1Seg,
       ORIGIN_POINTS=....Segments.Left.R1Seg.IC_points.Inn_InfPoints,
@@ -1494,7 +1494,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R1R2
     )={DesiredAngle = 0;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Inn_R2R3 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Inn_R2R3 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R2Seg,
       ORIGIN_POINTS=....Segments.Left.R2Seg.IC_points.Inn_InfPoints,
@@ -1504,7 +1504,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-     Muscle_template_Simple_Angle_MultiOffset IC_Inn_R3R4 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Inn_R3R4 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R3Seg,
       ORIGIN_POINTS=....Segments.Left.R3Seg.IC_points.Inn_InfPoints,
@@ -1513,7 +1513,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R3R4
     )={DesiredAngle = 0;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Inn_R4R5 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Inn_R4R5 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R4Seg,
       ORIGIN_POINTS=....Segments.Left.R4Seg.IC_points.Inn_InfPoints,
@@ -1523,7 +1523,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R5R6 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R5R6 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R5Seg,
       ORIGIN_POINTS=....Segments.Left.R5Seg.IC_points.Inn_InfPoints,
@@ -1533,7 +1533,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R6R7 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R6R7 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R6Seg,
       ORIGIN_POINTS=....Segments.Left.R6Seg.IC_points.Inn_InfPoints,
@@ -1542,7 +1542,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R6R7
     )={DesiredAngle = 0;};
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R7R8 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R7R8 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R7Seg,
       ORIGIN_POINTS=....Segments.Left.R7Seg.IC_points.Inn_InfPoints,
@@ -1552,7 +1552,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
 
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R8R9 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R8R9 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R8Seg,
       ORIGIN_POINTS=....Segments.Left.R8Seg.IC_points.Inn_InfPoints,
@@ -1561,7 +1561,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R8R9
     )={DesiredAngle = 0;};
 
-    Muscle_template_Simple_Angle_MultiOffset IC_Inn_R9R10 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Inn_R9R10 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Left.R9Seg,
       ORIGIN_POINTS=....Segments.Left.R9Seg.IC_points.Inn_InfPoints,
@@ -1570,7 +1570,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R9R10
     )={DesiredAngle = 0;};
  
-    Muscle_template_Simple_Angle_MultiOffset IC_Inn_R10R11 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Inn_R10R11 (
    CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Left.R10Seg,
       ORIGIN_POINTS=....Segments.Left.R10Seg.IC_points.Inn_InfPoints,
@@ -1580,7 +1580,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R11R12 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R11R12 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-4),
       OriginSegment=....Segments.Left.R11Seg,
       ORIGIN_POINTS=....Segments.Left.R11Seg.IC_points.Inn_InfPoints,
@@ -1598,7 +1598,7 @@ AnyFolder InterCostalisExternal =
   AnyFolder InternalInterCostalis ={
   
   
- Muscle_template_Simple_Angle_MultiOffset IC_Int_R1R2 (
+ SplineMuscle_CreateMuscleMultiOffset IC_Int_R1R2 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1-3),
       OriginSegment=....Segments.Left.R1Seg,
       ORIGIN_POINTS=....Segments.Left.R1Seg.IC_points.Int_InfPoints,
@@ -1625,7 +1625,7 @@ AnyFolder InterCostalisExternal =
     
     };
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Int_R2R3 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Int_R2R3 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R2Seg,
       ORIGIN_POINTS=....Segments.Left.R2Seg.IC_points.Int_InfPoints,
@@ -1652,7 +1652,7 @@ AnyFolder InterCostalisExternal =
     };
 
     
-     Muscle_template_Simple_Angle_MultiOffset IC_Int_R3R4 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Int_R3R4 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R3Seg,
       ORIGIN_POINTS=....Segments.Left.R3Seg.IC_points.Int_InfPoints,
@@ -1676,7 +1676,7 @@ AnyFolder InterCostalisExternal =
 
     };
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Int_R4R5 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Int_R4R5 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R4Seg,
       ORIGIN_POINTS=....Segments.Left.R4Seg.IC_points.Int_InfPoints,
@@ -1700,7 +1700,7 @@ AnyFolder InterCostalisExternal =
     };
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R5R6 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R5R6 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R5Seg,
       ORIGIN_POINTS=....Segments.Left.R5Seg.IC_points.Int_InfPoints,
@@ -1726,7 +1726,7 @@ AnyFolder InterCostalisExternal =
     };
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R6R7 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R6R7 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R6Seg,
       ORIGIN_POINTS=....Segments.Left.R6Seg.IC_points.Int_InfPoints,
@@ -1750,7 +1750,7 @@ AnyMuscleViaPoint elem_sternum= {
       };    
 };
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R7R8 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R7R8 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R7Seg,
       ORIGIN_POINTS=....Segments.Left.R7Seg.IC_points.Int_InfPoints,
@@ -1779,7 +1779,7 @@ AnyMuscleViaPoint elem_sternum= {
  };
 
 
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R8R9 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R8Seg,
       ORIGIN_POINTS=....Segments.Left.R8Seg.IC_points.Int_InfPoints,
@@ -1805,7 +1805,7 @@ AnyMuscleViaPoint elem_sternum= {
       }; 
     };
     
-    Muscle_template_Simple_Angle_MultiOffset IC_Int_R9R10 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Int_R9R10 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R9Seg,
       ORIGIN_POINTS=....Segments.Left.R9Seg.IC_points.Int_InfPoints,
@@ -1832,7 +1832,7 @@ AnyMuscleViaPoint elem_sternum= {
     };
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R10R11 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Left.R10Seg,
       ORIGIN_POINTS=....Segments.Left.R10Seg.IC_points.Int_InfPoints,
@@ -1842,7 +1842,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=-45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R11R12 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R11R12 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-4),
       OriginSegment=....Segments.Left.R11Seg,
       ORIGIN_POINTS=....Segments.Left.R11Seg.IC_points.Int_InfPoints,
@@ -1858,7 +1858,7 @@ AnyMuscleViaPoint elem_sternum= {
   AnyFolder ExternalInterCostalis ={
   
   
- Muscle_template_Simple_Angle_MultiOffset IC_Ext_R1R2 (
+ SplineMuscle_CreateMuscleMultiOffset IC_Ext_R1R2 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R1Seg,
       ORIGIN_POINTS=....Segments.Left.R1Seg.IC_points.Ext_InfPoints,
@@ -1867,7 +1867,7 @@ AnyMuscleViaPoint elem_sternum= {
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R1R2
     )={DesiredAngle=45;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Ext_R2R3 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Ext_R2R3 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R2Seg,
       ORIGIN_POINTS=....Segments.Left.R2Seg.IC_points.Ext_InfPoints,
@@ -1877,7 +1877,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-     Muscle_template_Simple_Angle_MultiOffset IC_Ext_R3R4 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Ext_R3R4 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R3Seg,
       ORIGIN_POINTS=....Segments.Left.R3Seg.IC_points.Ext_InfPoints,
@@ -1886,7 +1886,7 @@ AnyMuscleViaPoint elem_sternum= {
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R3R4
     )={DesiredAngle=45;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Ext_R4R5 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Ext_R4R5 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R4Seg,
       ORIGIN_POINTS=....Segments.Left.R4Seg.IC_points.Ext_InfPoints,
@@ -1896,7 +1896,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R5R6 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R5R6 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R5Seg,
       ORIGIN_POINTS=....Segments.Left.R5Seg.IC_points.Ext_InfPoints,
@@ -1906,7 +1906,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R6R7 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R6R7 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R6Seg,
       ORIGIN_POINTS=....Segments.Left.R6Seg.IC_points.Ext_InfPoints,
@@ -1915,7 +1915,7 @@ AnyMuscleViaPoint elem_sternum= {
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R6R7
     )={DesiredAngle=45;};
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R7R8 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R7R8 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R7Seg,
       ORIGIN_POINTS=....Segments.Left.R7Seg.IC_points.Ext_InfPoints,
@@ -1925,7 +1925,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
 
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R8R9 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R8Seg,
       ORIGIN_POINTS=....Segments.Left.R8Seg.IC_points.Ext_InfPoints,
@@ -1933,7 +1933,7 @@ AnyMuscleViaPoint elem_sternum= {
       INSERTION_POINTS=....Segments.Left.R9Seg.IC_points.Ext_SupPoints,
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Left.InterCostalisExternal.IC_Ext_R8R9
     )={DesiredAngle=45;};
-     Muscle_template_Simple_Angle_MultiOffset IC_Ext_R9R10 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Ext_R9R10 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Left.R9Seg,
       ORIGIN_POINTS=....Segments.Left.R9Seg.IC_points.Ext_InfPoints,
@@ -1943,7 +1943,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-    Muscle_template_Simple_Angle_MultiOffset IC_Ext_R10R11 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Ext_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Left.R10Seg,
       ORIGIN_POINTS=....Segments.Left.R10Seg.IC_points.Ext_InfPoints,
@@ -1953,7 +1953,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R11R12 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R11R12 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-4),
       OriginSegment=....Segments.Left.R11Seg,
       ORIGIN_POINTS=....Segments.Left.R11Seg.IC_points.Ext_InfPoints,

--- a/Body/AAUHuman/Trunk/MusclesRight.any
+++ b/Body/AAUHuman/Trunk/MusclesRight.any
@@ -1024,7 +1024,7 @@ AnyFolder ErectorSpinae = {
 
 AnyFolder InterCostalisExternal = 
   {
-    Muscle_template_Simple IC_Ext_R1R2(
+    SplineMuscle_CreateMuscle IC_Ext_R1R2(
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Right.R1Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R1.Right.IC_R1_Ext_Inf.Points,
@@ -1033,7 +1033,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R1R2
     )={};
     
-    Muscle_template_Simple IC_Ext_R2R3 (
+    SplineMuscle_CreateMuscle IC_Ext_R2R3 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R2Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R2.Right.IC_R2_Ext_Inf.Points,
@@ -1042,7 +1042,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R2R3
     )={};
     
-    Muscle_template_Simple IC_Ext_R3R4 (
+    SplineMuscle_CreateMuscle IC_Ext_R3R4 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R3Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R3.Right.IC_R3_Ext_Inf.Points,
@@ -1051,7 +1051,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R3R4
     )={};
     
-    Muscle_template_Simple IC_Ext_R4R5 (
+    SplineMuscle_CreateMuscle IC_Ext_R4R5 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R4Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R4.Right.IC_R4_Ext_Inf.Points,
@@ -1060,7 +1060,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R4R5
     )={};
         
-    Muscle_template_Simple IC_Ext_R5R6 (
+    SplineMuscle_CreateMuscle IC_Ext_R5R6 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R5Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R5.Right.IC_R5_Ext_Inf.Points,
@@ -1069,7 +1069,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R5R6
     )={};
     
-    Muscle_template_Simple IC_Ext_R6R7 (
+    SplineMuscle_CreateMuscle IC_Ext_R6R7 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R6Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R6.Right.IC_R6_Ext_Inf.Points,
@@ -1078,7 +1078,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R6R7
     )={};
         
-    Muscle_template_Simple IC_Ext_R7R8 (
+    SplineMuscle_CreateMuscle IC_Ext_R7R8 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R7Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R7.Right.IC_R7_Ext_Inf.Points,
@@ -1087,7 +1087,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R7R8
     )={};
     
-    Muscle_template_Simple IC_Ext_R8R9 (
+    SplineMuscle_CreateMuscle IC_Ext_R8R9 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R8Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R8.Right.IC_R8_Ext_Inf.Points,
@@ -1096,7 +1096,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R8R9
     )={};
           
-    Muscle_template_Simple IC_Ext_R9R10 (
+    SplineMuscle_CreateMuscle IC_Ext_R9R10 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R9Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R9.Right.IC_R9_Ext_Inf.Points,
@@ -1105,7 +1105,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R9R10
     )={};
       
-    Muscle_template_Simple IC_Ext_R10R11 (
+    SplineMuscle_CreateMuscle IC_Ext_R10R11 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Right.R10Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R10.Right.IC_R10_Ext_Inf.Points,
@@ -1114,7 +1114,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R10R11
     )={};
     
-    Muscle_template_Simple IC_Ext_R11R12 (
+    SplineMuscle_CreateMuscle IC_Ext_R11R12 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-2),
       OriginSegment=....Segments.Right.R11Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R11.Right.IC_R11_Ext_Inf.Points,
@@ -1128,7 +1128,7 @@ AnyFolder InterCostalisExternal =
   {
   
   
-    Muscle_template_Simple IC_Int_R1R2 (
+    SplineMuscle_CreateMuscle IC_Int_R1R2 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Right.R1Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R1.Right.IC_R1_Int_Inf.Points,
@@ -1154,7 +1154,7 @@ AnyFolder InterCostalisExternal =
     
 
     
-    Muscle_template_Simple IC_Int_R2R3 (
+    SplineMuscle_CreateMuscle IC_Int_R2R3 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R2Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R2.Right.IC_R2_Int_Inf.Points,
@@ -1177,7 +1177,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
         
-    Muscle_template_Simple IC_Int_R3R4 (
+    SplineMuscle_CreateMuscle IC_Int_R3R4 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R3Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R3.Right.IC_R3_Int_Inf.Points,
@@ -1200,7 +1200,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
         
-    Muscle_template_Simple IC_Int_R4R5 (
+    SplineMuscle_CreateMuscle IC_Int_R4R5 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
     OriginSegment=....Segments.Right.R4Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R4.Right.IC_R4_Int_Inf.Points,
@@ -1223,7 +1223,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
     
-    Muscle_template_Simple IC_Int_R5R6 (
+    SplineMuscle_CreateMuscle IC_Int_R5R6 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R5Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R5.Right.IC_R5_Int_Inf.Points,
@@ -1246,7 +1246,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
       
-    Muscle_template_Simple IC_Int_R6R7 (
+    SplineMuscle_CreateMuscle IC_Int_R6R7 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R6Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R6.Right.IC_R6_Int_Inf.Points,
@@ -1269,7 +1269,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
     
-    Muscle_template_Simple IC_Int_R7R8 (
+    SplineMuscle_CreateMuscle IC_Int_R7R8 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R7Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R7.Right.IC_R7_Int_Inf.Points,
@@ -1296,7 +1296,7 @@ AnyFolder InterCostalisExternal =
       };
     };
       
-    Muscle_template_Simple IC_Int_R8R9 (
+    SplineMuscle_CreateMuscle IC_Int_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R8Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R8.Right.IC_R8_Int_Inf.Points,
@@ -1321,7 +1321,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
         
-    Muscle_template_Simple IC_Int_R9R10 (
+    SplineMuscle_CreateMuscle IC_Int_R9R10 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R9Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R9.Right.IC_R9_Int_Inf.Points,
@@ -1346,7 +1346,7 @@ AnyFolder InterCostalisExternal =
       };    
     };
     
-    Muscle_template_Simple IC_Int_R10R11 (
+    SplineMuscle_CreateMuscle IC_Int_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
         OriginSegment=....Segments.Right.R10Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R10.Right.IC_R10_Int_Inf.Points,
@@ -1355,7 +1355,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisInternal.IC_Int_R10R11
     )={};
         
-    Muscle_template_Simple IC_Int_R11R12 (
+    SplineMuscle_CreateMuscle IC_Int_R11R12 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-1),
         OriginSegment=....Segments.Right.R11Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R11.Right.IC_R11_Int_Inf.Points,
@@ -1374,7 +1374,7 @@ AnyFolder InterCostalisExternal =
   AnyFolder InnermostInterCostalis = 
   {
 
-    Muscle_template_Simple IC_Inn_R1R2(
+    SplineMuscle_CreateMuscle IC_Inn_R1R2(
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
         OriginSegment=....Segments.Right.R1Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R1.Right.IC_R1_Inn_Inf.Points,
@@ -1383,7 +1383,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R1R2
     )={};
     
-    Muscle_template_Simple IC_Inn_R2R3 (
+    SplineMuscle_CreateMuscle IC_Inn_R2R3 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R2Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R2.Right.IC_R2_Inn_Inf.Points,
@@ -1392,7 +1392,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R2R3
     )={};
     
-    Muscle_template_Simple IC_Inn_R3R4 (
+    SplineMuscle_CreateMuscle IC_Inn_R3R4 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R3Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R3.Right.IC_R3_Inn_Inf.Points,
@@ -1401,7 +1401,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R3R4
     )={};
     
-    Muscle_template_Simple IC_Inn_R4R5 (
+    SplineMuscle_CreateMuscle IC_Inn_R4R5 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R4Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R4.Right.IC_R4_Inn_Inf.Points,
@@ -1410,7 +1410,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R4R5
     )={};
         
-    Muscle_template_Simple IC_Inn_R5R6 (
+    SplineMuscle_CreateMuscle IC_Inn_R5R6 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R5Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R5.Right.IC_R5_Inn_Inf.Points,
@@ -1419,7 +1419,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R5R6
     )={};
     
-    Muscle_template_Simple IC_Inn_R6R7 (
+    SplineMuscle_CreateMuscle IC_Inn_R6R7 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R6Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R6.Right.IC_R6_Inn_Inf.Points,
@@ -1428,7 +1428,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R6R7
     )={};
         
-    Muscle_template_Simple IC_Inn_R7R8 (
+    SplineMuscle_CreateMuscle IC_Inn_R7R8 (
         CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R7Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R7.Right.IC_R7_Inn_Inf.Points,
@@ -1437,7 +1437,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R7R8
     )={};
     
-    Muscle_template_Simple IC_Inn_R8R9 (
+    SplineMuscle_CreateMuscle IC_Inn_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R8Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R8.Right.IC_R8_Inn_Inf.Points,
@@ -1446,7 +1446,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R8R9
     )={};
           
-    Muscle_template_Simple IC_Inn_R9R10 (
+    SplineMuscle_CreateMuscle IC_Inn_R9R10 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
         OriginSegment=....Segments.Right.R9Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R9.Right.IC_R9_Inn_Inf.Points,
@@ -1455,7 +1455,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R9R10
     )={};
       
-    Muscle_template_Simple IC_Inn_R10R11 (
+    SplineMuscle_CreateMuscle IC_Inn_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
         OriginSegment=....Segments.Right.R10Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R10.Right.IC_R10_Inn_Inf.Points,
@@ -1464,7 +1464,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R10R11
     )={};
     
-    Muscle_template_Simple IC_Inn_R11R12 (
+    SplineMuscle_CreateMuscle IC_Inn_R11R12 (
         CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-2),
         OriginSegment=....Segments.Right.R11Seg,
       ORIGIN_POINTS=....Data.unscaled.ModelParameters.R11.Right.IC_R11_Inn_Inf.Points,
@@ -1496,7 +1496,7 @@ AnyFolder InterCostalisExternal =
   
     
     
- Muscle_template_Simple_Angle_MultiOffset IC_Inn_R1R2 (
+ SplineMuscle_CreateMuscleMultiOffset IC_Inn_R1R2 (
       CREATE_ELEMENTS= IC_MULTIPLIER*IC_SIZE,
       OriginSegment=....Segments.Right.R1Seg,
       ORIGIN_POINTS=....Segments.Right.R1Seg.IC_points.Inn_InfPoints,
@@ -1505,7 +1505,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R1R2
     )={DesiredAngle = 0;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Inn_R2R3 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Inn_R2R3 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R2Seg,
       ORIGIN_POINTS=....Segments.Right.R2Seg.IC_points.Inn_InfPoints,
@@ -1515,7 +1515,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-     Muscle_template_Simple_Angle_MultiOffset IC_Inn_R3R4 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Inn_R3R4 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R3Seg,
       ORIGIN_POINTS=....Segments.Right.R3Seg.IC_points.Inn_InfPoints,
@@ -1524,7 +1524,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R3R4
     )={DesiredAngle = 0;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Inn_R4R5 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Inn_R4R5 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R4Seg,
       ORIGIN_POINTS=....Segments.Right.R4Seg.IC_points.Inn_InfPoints,
@@ -1534,7 +1534,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R5R6 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R5R6 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R5Seg,
       ORIGIN_POINTS=....Segments.Right.R5Seg.IC_points.Inn_InfPoints,
@@ -1544,7 +1544,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R6R7 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R6R7 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R6Seg,
       ORIGIN_POINTS=....Segments.Right.R6Seg.IC_points.Inn_InfPoints,
@@ -1553,7 +1553,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R6R7
     )={DesiredAngle = 0;};
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R7R8 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R7R8 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R7Seg,
       ORIGIN_POINTS=....Segments.Right.R7Seg.IC_points.Inn_InfPoints,
@@ -1563,7 +1563,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
 
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R8R9 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R8R9 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R8Seg,
       ORIGIN_POINTS=....Segments.Right.R8Seg.IC_points.Inn_InfPoints,
@@ -1572,7 +1572,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R8R9
     )={DesiredAngle = 0;};
 
-    Muscle_template_Simple_Angle_MultiOffset IC_Inn_R9R10 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Inn_R9R10 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+3),
       OriginSegment=....Segments.Right.R9Seg,
       ORIGIN_POINTS=....Segments.Right.R9Seg.IC_points.Inn_InfPoints,
@@ -1581,7 +1581,7 @@ AnyFolder InterCostalisExternal =
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R9R10
     )={DesiredAngle = 0;};
  
-    Muscle_template_Simple_Angle_MultiOffset IC_Inn_R10R11 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Inn_R10R11 (
    CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Right.R10Seg,
       ORIGIN_POINTS=....Segments.Right.R10Seg.IC_points.Inn_InfPoints,
@@ -1591,7 +1591,7 @@ AnyFolder InterCostalisExternal =
     )={DesiredAngle = 0;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Inn_R11R12 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Inn_R11R12 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-4),
       OriginSegment=....Segments.Right.R11Seg,
       ORIGIN_POINTS=....Segments.Right.R11Seg.IC_points.Inn_InfPoints,
@@ -1609,7 +1609,7 @@ AnyFolder InterCostalisExternal =
   AnyFolder InternalInterCostalis ={
   
   
- Muscle_template_Simple_Angle_MultiOffset IC_Int_R1R2 (
+ SplineMuscle_CreateMuscleMultiOffset IC_Int_R1R2 (
       CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1-3),
       OriginSegment=....Segments.Right.R1Seg,
       ORIGIN_POINTS=....Segments.Right.R1Seg.IC_points.Int_InfPoints,
@@ -1636,7 +1636,7 @@ AnyFolder InterCostalisExternal =
     
     };
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Int_R2R3 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Int_R2R3 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R2Seg,
       ORIGIN_POINTS=....Segments.Right.R2Seg.IC_points.Int_InfPoints,
@@ -1663,7 +1663,7 @@ AnyFolder InterCostalisExternal =
     };
 
     
-     Muscle_template_Simple_Angle_MultiOffset IC_Int_R3R4 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Int_R3R4 (
      CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R3Seg,
       ORIGIN_POINTS=....Segments.Right.R3Seg.IC_points.Int_InfPoints,
@@ -1687,7 +1687,7 @@ AnyFolder InterCostalisExternal =
 
     };
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Int_R4R5 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Int_R4R5 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R4Seg,
       ORIGIN_POINTS=....Segments.Right.R4Seg.IC_points.Int_InfPoints,
@@ -1711,7 +1711,7 @@ AnyFolder InterCostalisExternal =
     };
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R5R6 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R5R6 (
     CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R5Seg,
       ORIGIN_POINTS=....Segments.Right.R5Seg.IC_points.Int_InfPoints,
@@ -1737,7 +1737,7 @@ AnyFolder InterCostalisExternal =
     };
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R6R7 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R6R7 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R6Seg,
       ORIGIN_POINTS=....Segments.Right.R6Seg.IC_points.Int_InfPoints,
@@ -1761,7 +1761,7 @@ AnyMuscleViaPoint elem_sternum= {
       };    
 };
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R7R8 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R7R8 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R7Seg,
       ORIGIN_POINTS=....Segments.Right.R7Seg.IC_points.Int_InfPoints,
@@ -1790,7 +1790,7 @@ AnyMuscleViaPoint elem_sternum= {
  };
 
 
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R8R9 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R8Seg,
       ORIGIN_POINTS=....Segments.Right.R8Seg.IC_points.Int_InfPoints,
@@ -1816,7 +1816,7 @@ AnyMuscleViaPoint elem_sternum= {
       }; 
     };
     
-    Muscle_template_Simple_Angle_MultiOffset IC_Int_R9R10 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Int_R9R10 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R9Seg,
       ORIGIN_POINTS=....Segments.Right.R9Seg.IC_points.Int_InfPoints,
@@ -1843,7 +1843,7 @@ AnyMuscleViaPoint elem_sternum= {
     };
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R10R11 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Right.R10Seg,
       ORIGIN_POINTS=....Segments.Right.R10Seg.IC_points.Int_InfPoints,
@@ -1853,7 +1853,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=-45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Int_R11R12 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Int_R11R12 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-4),
       OriginSegment=....Segments.Right.R11Seg,
       ORIGIN_POINTS=....Segments.Right.R11Seg.IC_points.Int_InfPoints,
@@ -1869,7 +1869,7 @@ AnyMuscleViaPoint elem_sternum= {
   AnyFolder ExternalInterCostalis ={
   
   
- Muscle_template_Simple_Angle_MultiOffset IC_Ext_R1R2 (
+ SplineMuscle_CreateMuscleMultiOffset IC_Ext_R1R2 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R1Seg,
       ORIGIN_POINTS=....Segments.Right.R1Seg.IC_points.Ext_InfPoints,
@@ -1878,7 +1878,7 @@ AnyMuscleViaPoint elem_sternum= {
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R1R2
     )={DesiredAngle=45;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Ext_R2R3 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Ext_R2R3 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R2Seg,
       ORIGIN_POINTS=....Segments.Right.R2Seg.IC_points.Ext_InfPoints,
@@ -1888,7 +1888,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-     Muscle_template_Simple_Angle_MultiOffset IC_Ext_R3R4 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Ext_R3R4 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R3Seg,
       ORIGIN_POINTS=....Segments.Right.R3Seg.IC_points.Ext_InfPoints,
@@ -1897,7 +1897,7 @@ AnyMuscleViaPoint elem_sternum= {
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R3R4
     )={DesiredAngle=45;};
 
-   Muscle_template_Simple_Angle_MultiOffset IC_Ext_R4R5 (
+   SplineMuscle_CreateMuscleMultiOffset IC_Ext_R4R5 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R4Seg,
       ORIGIN_POINTS=....Segments.Right.R4Seg.IC_points.Ext_InfPoints,
@@ -1907,7 +1907,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R5R6 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R5R6 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R5Seg,
       ORIGIN_POINTS=....Segments.Right.R5Seg.IC_points.Ext_InfPoints,
@@ -1917,7 +1917,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R6R7 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R6R7 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R6Seg,
       ORIGIN_POINTS=....Segments.Right.R6Seg.IC_points.Ext_InfPoints,
@@ -1926,7 +1926,7 @@ AnyMuscleViaPoint elem_sternum= {
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R6R7
     )={DesiredAngle=45;};
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R7R8 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R7R8 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R7Seg,
       ORIGIN_POINTS=....Segments.Right.R7Seg.IC_points.Ext_InfPoints,
@@ -1936,7 +1936,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
 
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R8R9 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R8R9 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R8Seg,
       ORIGIN_POINTS=....Segments.Right.R8Seg.IC_points.Ext_InfPoints,
@@ -1944,7 +1944,7 @@ AnyMuscleViaPoint elem_sternum= {
       INSERTION_POINTS=....Segments.Right.R9Seg.IC_points.Ext_SupPoints,
       MUSCLE_MODEL_PARAMETERS=....MuscleModels.Right.InterCostalisExternal.IC_Ext_R8R9
     )={DesiredAngle=45;};
-     Muscle_template_Simple_Angle_MultiOffset IC_Ext_R9R10 (
+     SplineMuscle_CreateMuscleMultiOffset IC_Ext_R9R10 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE+1),
       OriginSegment=....Segments.Right.R9Seg,
       ORIGIN_POINTS=....Segments.Right.R9Seg.IC_points.Ext_InfPoints,
@@ -1954,7 +1954,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-    Muscle_template_Simple_Angle_MultiOffset IC_Ext_R10R11 (
+    SplineMuscle_CreateMuscleMultiOffset IC_Ext_R10R11 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE),
       OriginSegment=....Segments.Right.R10Seg,
       ORIGIN_POINTS=....Segments.Right.R10Seg.IC_points.Ext_InfPoints,
@@ -1964,7 +1964,7 @@ AnyMuscleViaPoint elem_sternum= {
     )={DesiredAngle=45;};
 
     
-       Muscle_template_Simple_Angle_MultiOffset IC_Ext_R11R12 (
+       SplineMuscle_CreateMuscleMultiOffset IC_Ext_R11R12 (
        CREATE_ELEMENTS=IC_MULTIPLIER*(IC_SIZE-4),
       OriginSegment=....Segments.Right.R11Seg,
       ORIGIN_POINTS=....Segments.Right.R11Seg.IC_points.Ext_InfPoints,


### PR DESCRIPTION
This PR renames a few code macros and templates to make the names less generic and less likely to interfere with other variable names