### PR TITLE
fix: Cervical spine axial rotation rhythm coefficient fix

### DIFF
--- a/Body/AAUHuman/Trunk/JointsCervical.any
+++ b/Body/AAUHuman/Trunk/JointsCervical.any
@@ -219,7 +219,7 @@ AnyFolder Rotation = {
    
    RhythmDriverLinear rhythmC2C1SkullThoraxRotation( _REDEFINE_VARIABLES=On) = 
    {
-     AnyVector RhythmCoefficients ??= {132/77, 0.7967};
+     AnyVector RhythmCoefficients ??= {0.2721+0.3061, 0.2721};
      
      Measures.Input  = {
        AnyKinMeasure& ref = ...SkullThoraxRotation;

--- a/Body/AAUHuman/Trunk/JointsCervical.any
+++ b/Body/AAUHuman/Trunk/JointsCervical.any
@@ -219,8 +219,7 @@ AnyFolder Rotation = {
    
    RhythmDriverLinear rhythmC2C1SkullThoraxRotation( _REDEFINE_VARIABLES=On) = 
    {
-     // The -1 is because C2C1 is a revolute jnt and has the opposite signs for output.
-     AnyVector RhythmCoefficients ??= {132/77, -1};
+     AnyVector RhythmCoefficients ??= {132/77, 0.7967};
      
      Measures.Input  = {
        AnyKinMeasure& ref = ...SkullThoraxRotation;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The default pelvis model used in all models have changed. The pelvis morphology 
 **Fixed:**
 
 * Fixed the inclusion of the buckle segmental masses in the calculation of the TotalBodyMass variable.
+* Fixed the cervical spine axial rotation rhythm coefficients. The distribution between C2C1 and the rest of cervical spine was incorrect.
 
 **Added:**
 


### PR DESCRIPTION
The axial rotation rhythm coefficients for cervical spine were incorrect. The distribution between C2C1 and the rest of cervical spine was incorrect. It has been fixed now to match the expected distribution with more axial rotation in the rest of cervical spine (52.9%) and lesser rotation at C2C1 (47.1%).
