### PR TITLE
fix: Updated cervical rhythm implmentation

### DIFF
--- a/Application/Examples/ThoracicModel/Thoracic.main.any
+++ b/Application/Examples/ThoracicModel/Thoracic.main.any
@@ -4,24 +4,30 @@
 
 Main = {
  
+  ///////////////////////////////////////////////////
+  // Body Model Configuration. 
+  // This would often be located in a seperate 
+  // file (BodyModelConfig.any) in other examples
+  ///////////////////////////////////////////////////
   
   // New flexible thorax is enabled with:
   #define BM_TRUNK_THORACIC_MODEL _THORACIC_MODEL_FLEXIBLE_
-//  #define BM_TRUNK_CAVITY_MODEL _CAVITY_MODEL_BUCKLE_
   
   #define BM_LEG_MODEL OFF
-  
   #define BM_ARM_LEFT ON
   #define BM_ARM_RIGHT ON
   
   // Note: Model doesn't yet work without muscles
   #define BM_TRUNK_MUSCLES ON
-
+  
+  // The new thoracic model comes with a full set of
+  // ligaments all along the spine. They can be enabled
+  // with the following switch.
   #define BM_TRUNK_LIGAMENTS OFF 
   
 
-  // Remove default drivers so we can add custom fourier drivers
-  // to trunk in the this example
+  // This example comes with custom fourier drivers for the
+  // spine motion. So here we disable the default drivers 
   #define BM_MANNEQUIN_DRIVER_PELVIS_THORAX_EXTENSION OFF
   #define BM_MANNEQUIN_DRIVER_PELVIS_THORAX_ROTATION OFF
   #define BM_MANNEQUIN_DRIVER_PELVIS_THORAX_LATERAL_BENDING OFF

--- a/Application/Examples/ThoracicModel/Thoracic.main.any
+++ b/Application/Examples/ThoracicModel/Thoracic.main.any
@@ -11,6 +11,7 @@ Main = {
   ///////////////////////////////////////////////////
   
   // New flexible thorax is enabled with:
+//  #define BM_TRUNK_THORACIC_MODEL _THORACIC_MODEL_RIGID_
   #define BM_TRUNK_THORACIC_MODEL _THORACIC_MODEL_FLEXIBLE_
   
   #define BM_LEG_MODEL OFF

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.any
@@ -174,7 +174,7 @@
 
 // The lumbar and thoracic movements are linked so the move simultaneously. This switch is used to enable this link.
 #ifndef BM_TRUNK_LUMBAR_THORACIC_LINK
-#define BM_TRUNK_LUMBAR_THORACIC_LINK ON
+#define BM_TRUNK_LUMBAR_THORACIC_LINK BM_TRUNK_RHYTHM
 #endif
 
 // A switch to control all the ligaments in the spine.

--- a/Body/AAUHuman/Documentation/BodyModel.parameters.any
+++ b/Body/AAUHuman/Documentation/BodyModel.parameters.any
@@ -177,7 +177,7 @@
 
 
 // The lumbar and thoracic movements are linked so the move simultaneously. This switch is used to enable this link.
-// #define  BM_TRUNK_LUMBAR_THORACIC_LINK ON
+// #define  BM_TRUNK_LUMBAR_THORACIC_LINK BM_TRUNK_RHYTHM
 // Possible values: ON, OFF, 
 
 

--- a/Body/AAUHuman/Trunk/JointsCervical.any
+++ b/Body/AAUHuman/Trunk/JointsCervical.any
@@ -240,3 +240,43 @@ AnyFolder Rotation = {
   
 };//Rotation
 
+
+#if BM_TRUNK_CERVICAL_THORACIC_LINK
+// See the documentation for the rhythms/links for better understanding of the numbers 
+// used for the coefficients. 
+RhythmDriverLinear CervicalThroacicRotationLinkDriver(_REDEFINE_VARIABLES=On) = 
+{
+    AnyVector RhythmCoefficients ??= {0.272+0.306, 0.102+0.32};
+    Measures.Input = {
+     AnyKinMeasure& SkullThoraxRotation_ref = ......Interface.Trunk.SkullThoraxRotation;      
+     AnyKinMeasure& T12T1_Rot_ref = ......Interface.Trunk.PelvisThoraxRotation;      
+    };
+        
+};   
+
+    
+RhythmDriverLinear CervicalThroacicLatBendingLinkDriver(_REDEFINE_VARIABLES=On) = 
+{
+    AnyVector RhythmCoefficients ??= {0.45, 0.275+0.275};
+    Measures.Input = {
+     AnyKinMeasure& SkullThoraxLateralBending_ref = ......Interface.Trunk.SkullThoraxLateralBending;      
+     AnyKinMeasure& T12T1_latbend_ref = ......Interface.Trunk.PelvisThoraxLateralBending;      
+    };
+};
+
+
+RhythmDriverBiLinear CervicalThroacicExtensionLinkDriver(NDIM=2, _REDEFINE_VARIABLES=On) = 
+{
+    AnyVector RhythmCoefficients ??= {0.311+0.115, -1*(0.144+0.430)};
+    AnyFloat RhythmCoefficientsNegative ??= {0.383+0.142, -1*(0.217+0.258)};
+    
+    // +/- 5 degree interval where rhythm transitions from one set of coefficients to the other
+    AnyFloat TransitionInterval ??= 5*pi/180;
+    
+    Measures.Input = {
+      AnyKinMeasure& SkullThoraxFlexion_ref = ......Interface.Trunk.SkullThoraxFlexion;      
+      AnyKinMeasure& T12T1_ext_ref = ......Interface.Trunk.PelvisThoraxExtension;      
+    };
+};
+#endif
+

--- a/Body/AAUHuman/Trunk/JointsThorax.any
+++ b/Body/AAUHuman/Trunk/JointsThorax.any
@@ -57,9 +57,9 @@
 
   
   #if BM_TRUNK_THORACIC_RHYTHM != OFF
-  
-  
-  
+  // See the documentation for the rhythms/links for better understanding of the numbers 
+  // used for the coefficients. 
+
     RhythmDriverLinear LateralBendingRhythmDriver(RELATIVE_TO_DOF=10, _REDEFINE_VARIABLES=On) = 
     {
          //The RhythmCoefficients represent the realative change of the different measures 
@@ -131,8 +131,8 @@
     #if BM_TRUNK_LUMBAR_THORACIC_LINK
     RhythmDriverBiLinear LumbarThroacicExtensionLinkDriver(NDIM=2, _REDEFINE_VARIABLES=On) = 
     {
-        AnyVector RhythmCoefficients ??= {0.54, 0.46};
-        AnyFloat RhythmCoefficientsNegative ??= {0.75, 0.25};
+        AnyVector RhythmCoefficients ??= {0.258, 0.217};
+        AnyFloat RhythmCoefficientsNegative ??= {0.43, 0.14};
         
         // +/- 5 degree interval where rhythm transitions from one set of coefficients to the other
         AnyFloat TransitionInterval ??= 5*pi/180;
@@ -146,7 +146,7 @@
         
     RhythmDriverLinear LumbarThroacicLatBendingLinkDriver(_REDEFINE_VARIABLES=On) = 
     {
-        AnyVector RhythmCoefficients ??= {0.5, 0.5};
+        AnyVector RhythmCoefficients ??= {0.275, 0.275};
         Measures.Input = {
          AnyKinMeasure& PelvisT12_Latbend_ref = ......Interface.Trunk.PelvisT12LateralBending;      
          AnyKinMeasure& T12T1_latbend_ref = ......Interface.Trunk.T12T1LateralBending;      
@@ -155,7 +155,7 @@
     
     RhythmDriverLinear LumbarThroacicRotationLinkDriver(_REDEFINE_VARIABLES=On) = 
     {
-        AnyVector RhythmCoefficients ??= {0.24, 0.76};
+        AnyVector RhythmCoefficients ??= {0.102, 0.320};
         Measures.Input = {
          AnyKinMeasure& PelvisT12_Rot_ref = ......Interface.Trunk.PelvisT12Rotation;      
          AnyKinMeasure& T12T1_Rot_ref = ......Interface.Trunk.T12T1Rotation;      
@@ -163,46 +163,6 @@
     }; 
     #endif
     
-    
-    #if BM_TRUNK_CERVICAL_THORACIC_LINK
-    RhythmDriverLinear CervicalThroacicRotationLinkDriver(_REDEFINE_VARIABLES=On) = 
-    {
-        AnyVector RhythmCoefficients ??= {0.6, 0.4};
-        Measures.Input = {
-         AnyKinMeasure& SkullThoraxRotation_ref = ......Interface.Trunk.SkullThoraxRotation;      
-         AnyKinMeasure& T12T1_Rot_ref = ......Interface.Trunk.T12T1Rotation;      
-        };
-            
-    };   
-    
-        
-    RhythmDriverLinear CervicalThroacicLatBendingLinkDriver(_REDEFINE_VARIABLES=On) = 
-    {
-        AnyVector RhythmCoefficients ??= {0.6, 0.4};
-        Measures.Input = {
-         AnyKinMeasure& SkullThoraxLateralBending_ref = ......Interface.Trunk.SkullThoraxLateralBending;      
-         AnyKinMeasure& T12T1_latbend_ref = ......Interface.Trunk.T12T1LateralBending;      
-        };
-    };
-
-
-    RhythmDriverBiLinear CervicalThroacicExtensionLinkDriver(NDIM=2, _REDEFINE_VARIABLES=On) = 
-    {
-        AnyVector RhythmCoefficients ??= {0.6, -0.4};
-        AnyFloat RhythmCoefficientsNegative ??= {0.7, -0.3};
-        
-        // +/- 5 degree interval where rhythm transitions from one set of coefficients to the other
-        AnyFloat TransitionInterval ??= 5*pi/180;
-        
-        Measures.Input = {
-          AnyKinMeasure& SkullThoraxFlexion_ref = ......Interface.Trunk.SkullThoraxFlexion;      
-          AnyKinMeasure& T12T1_ext_ref = ......Interface.Trunk.T12T1Extension;      
-        };
-    };
-    #endif
-    
-    
-
   #endif
 
 #endif

--- a/Body/AAUHuman/bm-parameters.toml
+++ b/Body/AAUHuman/bm-parameters.toml
@@ -735,7 +735,7 @@ descr = "The cervical and thoracic movements are linked so the move simultaneous
 opt = [ "OFF", "ON"]
 
 [parameters.BM_TRUNK_LUMBAR_THORACIC_LINK]
-default = "ON"
+default = "BM_TRUNK_RHYTHM"
 valuetype = "integer"
 nicename = "Lumbar-Thoracic link rhythm"
 descr = "The lumbar and thoracic movements are linked so the move simultaneously. This switch is used to enable this link."

--- a/Docs/bm_config/bm_statements.md
+++ b/Docs/bm_config/bm_statements.md
@@ -703,8 +703,8 @@ The cervical and thoracic movements are linked so the move simultaneously. This 
 
 The lumbar and thoracic movements are linked so the move simultaneously. This switch is used to enable this link.
 
-:Default: ON
-:Example: `#define BM_TRUNK_LUMBAR_THORACIC_LINK ON`
+:Default: {any}`BM_TRUNK_RHYTHM`
+:Example: `#define BM_TRUNK_LUMBAR_THORACIC_LINK BM_TRUNK_RHYTHM`
 :Options:
   - {any}`ON` -> Switch ON
   - {any}`OFF` -> Switch OFF


### PR DESCRIPTION
This pull request introduces updates to the thoracic model configuration, rhythm drivers. The most important changes include the addition of a flexible thorax model, adjustments to rhythm driver coefficients, and updates to documentation and default settings.

@Hamedshayestehpour I have fixed the problem you found with the Thoracic example not working with the rigid thorax. 

This PR refactors the cervical rhythm link. When the link is enabled it now links the cervical rhythm to the entire spine (pelvis-T1 measure). This means that the link works both for the detailed and the rigid thorax. To accomplish this I needed to move the implementation to the "JointsCervical.any" file. 

The coefficients for the rhythm links have also been changed to they are now given directly by the values from the 'excel' sheet where the rhythm was created. I still need to add more documentation on the rhythm to the AMMR. But that may come in future PR.


### Thoracic Model Configuration:
* Added a flexible thorax model with a full set of ligaments along the spine in `Thoracic.main.any`.

### Rhythm Driver Adjustments:
* Adjusted rhythm driver coefficients for lumbar-thoracic and cervical-thoracic links in `JointsThorax.any`. [[1]](diffhunk://#diff-77ba4bc5c2437948d9b2498a2f96bdfb2bed790878fdc1d59953bdbb54c056acL134-R135) [[2]](diffhunk://#diff-77ba4bc5c2437948d9b2498a2f96bdfb2bed790878fdc1d59953bdbb54c056acL149-R149) [[3]](diffhunk://#diff-77ba4bc5c2437948d9b2498a2f96bdfb2bed790878fdc1d59953bdbb54c056acL158-L205)
* Introduced new rhythm drivers for cervical-thoracic links in `JointsCervical.any`.
