### PR TITLE
feat: Add y rotation actuator to abdomen layer

### DIFF
--- a/Body/AAUHuman/Trunk/Abdominal/AbdominalPressureModel.any
+++ b/Body/AAUHuman/Trunk/Abdominal/AbdominalPressureModel.any
@@ -1028,7 +1028,7 @@ AnyFolder Abdominal={
           Axis1 = x; Axis2 = y; Axis3 = z;
           Type = RotAxesAngles;
         };
-        MeasureOrganizer = {0,2,3,5,6,8,9,11}; //{0,2,3,5,6,8,9,11,12,14};
+//        MeasureOrganizer = {0,2,3,5,6,8,9,11}; //{0,2,3,5,6,8,9,11,12,14};
         
       }; 
       Type = NonNegative;


### PR DESCRIPTION
Add y rotation actuator to abdomen layer to avoid spike in obliq muscle activity, when they want to balance the layer masses