### PR TITLE
fix: Change wrapping surface from cylinder to ellipsoid for muscles at the wrist

### DIFF
--- a/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
+++ b/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
@@ -313,6 +313,22 @@ AnyFolder Radius = {
   AnyFloat WristFlexorCyl_P3_pos = WristFlexorCyl_pos + {0.0,0.0,-0.0130};
   AnyFloat WristFlexorCyl_P2_pos = WristFlexorCyl_pos + {0.003, 0.025,0.0};
     
+  AnyFloat WristFlexorEllipsoid_pos = wj_pos + {0.009210971, -0.0003975198, -0.0014};
+  AnyFloat WristFlexorEllipsoid_P3_pos = {-0.2158542, -0.01637023, 0.009193912}; // x axis
+  AnyFloat WristFlexorEllipsoid_P2_pos = {-0.2250712, -0.006009247, 0.01196824}; // y axis
+  
+  AnyFloat WristFlexorTorus_pos = wj_pos + {0.002939388, 0.001697056, 0.0056};
+  AnyFloat WristFlexorTorus_P3_pos = {-0.2312188, -0.01352852, 0.005638053}; // x axis
+  AnyFloat WristFlexorTorus_P2_pos = {-0.2320511, -0.003305493, 0.01537442}; // y axis
+  
+  AnyFloat WristExtensorEllipsoid_pos = wj_pos + {0.001862501, -0.00464016, -0.001};
+  AnyFloat WristExtensorEllipsoid_P3_pos = {-0.2232895, -0.02137677, 0.009015211}; // x axis
+  AnyFloat WristExtensorEllipsoid_P2_pos = {-0.2314014, -0.009793548, 0.00917386}; // y axis
+  
+  AnyFloat WristExtensorTorus_pos = wj_pos + {0.005157799, 0.003794353, -0.0046};
+  AnyFloat WristExtensorTorus_P3_pos = {-0.2316853, -0.0107118, -0.004416272}; // x axis
+  AnyFloat WristExtensorTorus_P2_pos = {-0.2303107, -0.001234046, 0.005989632}; // y axis
+  
   AnyVec3 correction ={0,-0.005,0.00};
   
   AnyFloat I_Biceps_LH_pos                      = {-0.004634000, 0.01056600, -0.006213000};

--- a/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
+++ b/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
@@ -316,19 +316,11 @@ AnyFolder Radius = {
   AnyFloat WristFlexorEllipsoid_pos = wj_pos + {0.009210971, -0.0003975198, -0.0014};
   AnyFloat WristFlexorEllipsoid_P3_pos = {-0.2158542, -0.01637023, 0.009193912}; // x axis
   AnyFloat WristFlexorEllipsoid_P2_pos = {-0.2250712, -0.006009247, 0.01196824}; // y axis
-  
-  AnyFloat WristFlexorTorus_pos = wj_pos + {0.002939388, 0.001697056, 0.0056};
-  AnyFloat WristFlexorTorus_P3_pos = {-0.2312188, -0.01352852, 0.005638053}; // x axis
-  AnyFloat WristFlexorTorus_P2_pos = {-0.2320511, -0.003305493, 0.01537442}; // y axis
-  
+    
   AnyFloat WristExtensorEllipsoid_pos = wj_pos + {0.001862501, -0.00464016, -0.001};
   AnyFloat WristExtensorEllipsoid_P3_pos = {-0.2232895, -0.02137677, 0.009015211}; // x axis
   AnyFloat WristExtensorEllipsoid_P2_pos = {-0.2314014, -0.009793548, 0.00917386}; // y axis
-  
-  AnyFloat WristExtensorTorus_pos = wj_pos + {0.005157799, 0.003794353, -0.0046};
-  AnyFloat WristExtensorTorus_P3_pos = {-0.2316853, -0.0107118, -0.004416272}; // x axis
-  AnyFloat WristExtensorTorus_P2_pos = {-0.2303107, -0.001234046, 0.005989632}; // y axis
-  
+    
   AnyVec3 correction ={0,-0.005,0.00};
   
   AnyFloat I_Biceps_LH_pos                      = {-0.004634000, 0.01056600, -0.006213000};

--- a/Body/AAUHuman/Arm/Muscle.any
+++ b/Body/AAUHuman/Arm/Muscle.any
@@ -1744,17 +1744,7 @@ AnyMuscleShortestPath Extensor_Indicis ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Indicis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-        transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)               
-    };
-    InitWrapPosVecArr = {None, &InitWrapPos, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -1762,7 +1752,6 @@ AnyMuscleShortestPath Extensor_Indicis ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -1859,15 +1848,7 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Brevis ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Carpi_Radialis_Brevis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {transf3D({...Sign*1*.Surf1.Radius, 1.1*.Surf1.Radius, 0.35*.Surf1.Length }, &.Surf1)};
-    InitWrapPosVecArr = { None, &InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -1875,7 +1856,6 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Brevis ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 60;
   SPLine.RelTol=10e-6;
   SPLine.AbsTol=10e-6;
@@ -1928,19 +1908,7 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Carpi_Radialis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf2 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf2.Radius, -1.2*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2 ) ,              
-       transf3D({...Sign*0*.Surf2.Radius, -1.2*.Surf2.Radius, 0.45*.Surf2.Length }, &.Surf2 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-0.8*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -1948,7 +1916,6 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -1960,19 +1927,7 @@ AnyMuscleShortestPath Palmaris_Longus  ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Palmaris_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};  
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -1980,7 +1935,6 @@ AnyMuscleShortestPath Palmaris_Longus  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -1994,18 +1948,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Superficialis_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0.1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2013,7 +1956,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2026,19 +1968,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Superficialis_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2046,7 +1976,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2059,19 +1988,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Superficialis_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2079,7 +1996,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2091,19 +2007,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Superficialis_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-        transf3D({-0.015, ...Sign*0, -0.000}, &.Via1 ),               
-        transf3D({...Sign*0*.Surf1.Radius, -1.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos, None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2111,7 +2015,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 30;
 };
 
@@ -2124,18 +2027,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Profundus_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0.1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2143,7 +2035,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2156,18 +2047,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Profundus_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2175,7 +2055,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2188,18 +2067,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Profundus_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.42*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2207,7 +2075,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2221,18 +2088,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Profundus_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.42*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2240,7 +2096,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2254,19 +2109,7 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digitorum_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {    
-    AnyMatrix InitWrapPos1 = { 
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2274,7 +2117,6 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2289,19 +2131,7 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Extensor_Digitorum_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = { 
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};      
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2309,7 +2139,6 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2324,19 +2153,7 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Digitorum_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = { 
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2344,7 +2161,6 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2359,19 +2175,7 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Digitorum_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = {
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2379,7 +2183,6 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
 };
 
@@ -2393,19 +2196,7 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digiti_Minimi; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = {
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*0.5*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*0.5*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2,None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2413,7 +2204,6 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 30;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2428,18 +2218,7 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
   AnyRefNode &Ins = ..Seg.Hand.Finger1MetaRef.I_Flexor_Pollicis_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos, None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2447,7 +2226,6 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;

--- a/Body/AAUHuman/Arm/Muscle.any
+++ b/Body/AAUHuman/Arm/Muscle.any
@@ -285,7 +285,7 @@ AnyMuscleShortestPath deltoideus_posterior_part_1 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_posterior_part_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_posterior_part_1; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
-  SPLine.StringMesh = 35;
+  SPLine.StringMesh = 45;
 
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingPosterior.BASE_FRAME.Wrapping_1.Surf;
   AnyParamSurfAnalytical &Surf2 =..Seg.Scapula.deltoid_cyl.cyl; 
@@ -1743,17 +1743,28 @@ AnyMuscleShortestPath Extensor_Indicis ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger2MetaRef.Via1_Extensor_Indicis; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Indicis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
         transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)               
     };
     InitWrapPosVecArr = {None, &InitWrapPos, None };
   };
-
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleViaPoint Abductor_Pollicis_Longus ={
@@ -1847,14 +1858,27 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Brevis ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger3MetaRef.Via_Extensor_Carpi_Radialis_Brevis; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Carpi_Radialis_Brevis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 60;
-  SPLine.RelTol=10e-6;
-  SPLine.AbsTol=10e-6;
   SPLine = {
     AnyMatrix InitWrapPos = {transf3D({...Sign*1*.Surf1.Radius, 1.1*.Surf1.Radius, 0.35*.Surf1.Length }, &.Surf1)};
     InitWrapPosVecArr = { None, &InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*0.8*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 60;
+  SPLine.RelTol=10e-6;
+  SPLine.AbsTol=10e-6;
 };
 
 
@@ -1903,10 +1927,10 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Flexor_Carpi_Radialis; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Carpi_Radialis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf2 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf2.Radius, -1.2*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2 ) ,              
@@ -1914,6 +1938,19 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-0.8*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-0.7*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleShortestPath Palmaris_Longus  ={
@@ -1922,10 +1959,10 @@ AnyMuscleShortestPath Palmaris_Longus  ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Palmaris_Longus; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Palmaris_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};  
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
@@ -1933,6 +1970,19 @@ AnyMuscleShortestPath Palmaris_Longus  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],0.1*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 
@@ -1943,9 +1993,9 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger5MetaRef.Via_Flexor_Digitorum_Superficialis_Digit5; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Superficialis_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
@@ -1953,6 +2003,19 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
@@ -1962,10 +2025,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger4MetaRef.Via_Flexor_Digitorum_Superficialis_Digit4; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Superficialis_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
@@ -1973,6 +2036,19 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
@@ -1982,10 +2058,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger3MetaRef.Via_Flexor_Digitorum_Superficialis_Digit3; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Superficialis_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
@@ -1993,6 +2069,19 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
   AnyMuscleModel &MusMdl = ..MuscleModels.Flexor_Digitorum_Superficialis_Digit2; 
@@ -2001,9 +2090,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger2MetaRef.Via_Flexor_Digitorum_Superficialis_Digit2; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Superficialis_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 30;
   SPLine = {
     AnyMatrix InitWrapPos = {
         transf3D({-0.015, ...Sign*0, -0.000}, &.Via1 ),               
@@ -2011,7 +2101,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos, None};
   };
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 30;
 };
 
 
@@ -2022,8 +2123,9 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger5MetaRef.Via_Flexor_Digitorum_Profundus_Digit5; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Profundus_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
@@ -2031,7 +2133,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 
@@ -2042,8 +2155,9 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger4MetaRef.Via_Flexor_Digitorum_Profundus_Digit4; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Profundus_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
@@ -2051,7 +2165,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 
@@ -2062,8 +2187,9 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger3MetaRef.Via_Flexor_Digitorum_Profundus_Digit3; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Profundus_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
@@ -2071,6 +2197,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 
@@ -2082,8 +2220,9 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger2MetaRef.Via_Flexor_Digitorum_Profundus_Digit2; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Profundus_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
@@ -2091,6 +2230,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
@@ -2102,11 +2253,10 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
   
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digitorum_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {    
     AnyMatrix InitWrapPos1 = { 
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2114,7 +2264,21 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
     };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
+};
 
 
 AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
@@ -2124,11 +2288,10 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
   AnyRefNode &Via1 = ..Seg.Hand.Finger4MetaRef.Via_Extensor_Digitorum_Digit4; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Extensor_Digitorum_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos1 = { 
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2136,6 +2299,20 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.15*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };
 
 
@@ -2146,11 +2323,10 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
   AnyRefNode &Via1 = ..Seg.Hand.Finger3MetaRef.Via_Extensor_Digitorum_Digit3; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Digitorum_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos1 = { 
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2158,6 +2334,20 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.25*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };
 
 
@@ -2168,9 +2358,10 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
   AnyRefNode &Via1 = ..Seg.Hand.Finger2MetaRef.Via_Extensor_Digitorum_Digit2; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Digitorum_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
   SPLine = {
     AnyMatrix InitWrapPos1 = {
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2178,6 +2369,18 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.35*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
 };
 
 
@@ -2189,11 +2392,10 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger5MetaRef.Via_Extensor_Digiti_Minimi; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digiti_Minimi; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 30;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos1 = {
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*0.5*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2201,6 +2403,20 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2,None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 30;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };
 
 
@@ -2211,10 +2427,9 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
   AnyRefNode &Via2 = ..Seg.Hand.Finger1MetaRef.Via_Flexor_Pollicis_Longus; 
   AnyRefNode &Ins = ..Seg.Hand.Finger1MetaRef.I_Flexor_Pollicis_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
@@ -2222,4 +2437,18 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos, None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*-0.8*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };

--- a/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
+++ b/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
@@ -126,24 +126,7 @@ Radius = {
        Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
      };
    };
-   // It is used for wrapping of flexor muscles at wrist
-   AnyRefNode FlexorMuscleTorus = {
-     
-     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
-     sRel = P1;
-     AnyVec3 P1 = .Scale(.Data.WristFlexorTorus_pos*.Mirror);
-     AnyVec3 P3 = .Scale(.Data.WristFlexorTorus_P3_pos*.Mirror);
-     AnyVec3 P2 = .Scale(.Data.WristFlexorTorus_P2_pos*.Mirror);
-     
-     //Calculate orientation of Torus
-     ARel = RotMat(P1,P3,P2);
-     
-     AnySurfTorus torus = {
-       MajorRadius = .Radius;
-       MinorRadius = 0.2*MajorRadius;
-     };
-   };
-  
+   
    // It is used for wrapping of extensor muscles at wrist
    AnyRefNode ExtensorMuscleEllipsoid = {
      
@@ -159,23 +142,6 @@ Radius = {
      
      AnySurfEllipsoid ellipsoid = {
        Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
-     };
-   };
-   // It is used for wrapping of extensor muscles at wrist
-   AnyRefNode ExtensorMuscleTorus = {
-     
-     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
-     sRel = P1;
-     AnyVec3 P1 = .Scale(.Data.WristExtensorTorus_pos*.Mirror);
-     AnyVec3 P3 = .Scale(.Data.WristExtensorTorus_P3_pos*.Mirror);
-     AnyVec3 P2 = .Scale(.Data.WristExtensorTorus_P2_pos*.Mirror);
-     
-     //Calculate orientation of Torus
-     ARel = RotMat(P1,P3,P2);
-     
-     AnySurfTorus torus = {
-       MajorRadius = .Radius;
-       MinorRadius = 0.2*MajorRadius;
      };
    };
    

--- a/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
+++ b/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
@@ -109,7 +109,76 @@ Radius = {
    };
     
   
+   // It is used for wrapping of flexor muscles at wrist
+   AnyRefNode FlexorMuscleEllipsoid = {
+     
+     AnyVar DiameterXZ = vnorm(.Scale(.Data.Via_Palmaris_Longus_pos*.Mirror - .Data.Via_Extensor_Indicis_pos*.Mirror));
+     AnyVar DiameterY = vnorm(.Scale(.Data.PS_pos*.Mirror - .Data.rs_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristFlexorEllipsoid_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristFlexorEllipsoid_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristFlexorEllipsoid_P2_pos*.Mirror);
+     
+     //Calculate orientation of ellipsoid
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfEllipsoid ellipsoid = {
+       Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
+     };
+   };
+   // It is used for wrapping of flexor muscles at wrist
+   AnyRefNode FlexorMuscleTorus = {
+     
+     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristFlexorTorus_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristFlexorTorus_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristFlexorTorus_P2_pos*.Mirror);
+     
+     //Calculate orientation of Torus
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfTorus torus = {
+       MajorRadius = .Radius;
+       MinorRadius = 0.2*MajorRadius;
+     };
+   };
   
+   // It is used for wrapping of extensor muscles at wrist
+   AnyRefNode ExtensorMuscleEllipsoid = {
+     
+     AnyVar DiameterXZ = vnorm(.Scale(.Data.Via_Palmaris_Longus_pos*.Mirror - .Data.Via_Extensor_Indicis_pos*.Mirror));
+     AnyVar DiameterY = vnorm(.Scale(.Data.PS_pos*.Mirror - .Data.rs_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristExtensorEllipsoid_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristExtensorEllipsoid_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristExtensorEllipsoid_P2_pos*.Mirror);
+     
+     //Calculate orientation of ellipsoid
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfEllipsoid ellipsoid = {
+       Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
+     };
+   };
+   // It is used for wrapping of extensor muscles at wrist
+   AnyRefNode ExtensorMuscleTorus = {
+     
+     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristExtensorTorus_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristExtensorTorus_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristExtensorTorus_P2_pos*.Mirror);
+     
+     //Calculate orientation of Torus
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfTorus torus = {
+       MajorRadius = .Radius;
+       MinorRadius = 0.2*MajorRadius;
+     };
+   };
+   
   
   #include "../DrawSettings/SegmentAxes.any"
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ The default pelvis model used in all models have changed. The pelvis morphology 
 
   In practice, this means that the morphology of the leg pelvis is moprhed to match the Trunk pelvis.
   Using `_MORPH_TRUNK_TO_LEG_` instead will revert to the old behaviour. 
+* The wrapping surface for muscles at the wrist has been changed to an ellipsoid from a cylinder. This avoids
+  penetration of muscle in the wrapping surface in postures involving both flexion/extension and abduction/adduction at
+  the wrist.
 
 (ammr-3.1.0-changelog)=
 ## AMMR 3.1.0 (2024-??-??)


### PR DESCRIPTION
This PR changes the wrapping surface at the wrist to an ellipsoid. This prevents muscle penetration issues that we have seen with the previous wrapping cylinder in postures involving both flexion/extension and abduction/adduction at wrist.