### PR TITLE
feat: Add new reference nodes on shank

### DIFF
--- a/Body/AAUHuman/LegTLEM/Seg.any
+++ b/Body/AAUHuman/LegTLEM/Seg.any
@@ -716,6 +716,21 @@ AnySeg Shank =
        };
   };
   #endif
+
+  AnyRefNode TibiaFemurJointCavityCenter =
+  {
+    sRel = .Scale(.Data.TibiaFemurJointCavityCenter);
+    #if TLEM_JOINT_TYPE_KNEE != _JOINT_TYPE_USERDEFINED_
+    ARel ??= .KneeJoint.ARel;
+    #endif
+  };
+  AnyRefNode TibiaTalusJointCavityCenter =
+  {
+    sRel = .Scale(.Data.TibiaTalusJointCavityCenter);
+    #if TLEM_JOINT_TYPE_ANKLE != _JOINT_TYPE_USERDEFINED_
+    ARel ??= .AnkleJoint.ARel;
+    #endif
+  };
   
   //BonyLandMarks
   AnyRefNode MedialTibialEpicondyle =

--- a/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
+++ b/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
@@ -508,8 +508,8 @@ AnyFolder ModelParameters = {
     AnyVec3 MedialAnkleAxisMarker = MedialMalleolus;
     AnyVec3 LateralAnkleAxisMarker = LateralMalleolus;
     
-    AnyVec3 TibiaFemurJointCavityCenter = (KneeJoint+{0.01, -0.018, 0.0})*.TF';
-    AnyVec3 TibiaTalusJointCavityCenter = (0.5*(MedialMalleolus+LateralMalleolus)+{0.01, 0.008, 0})*.TF';
+    AnyVec3 TibiaFemurJointCavityCenter = KneeJoint+{0.01, -0.018, 0.0}*.TF';
+    AnyVec3 TibiaTalusJointCavityCenter = 0.5*(MedialMalleolus+LateralMalleolus)+({0.01, 0.008, 0})*.TF';
     
     AnyVec3 MedialTibialEpicondyle = {0, 0.321463224672736, -0.038645847149671}*.TF';
     AnyVec3 LateralTibialEpicondyle = {0, 0.319398338284877, 0.038645847149671}*.TF';

--- a/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
+++ b/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
@@ -508,6 +508,9 @@ AnyFolder ModelParameters = {
     AnyVec3 MedialAnkleAxisMarker = MedialMalleolus;
     AnyVec3 LateralAnkleAxisMarker = LateralMalleolus;
     
+    AnyVec3 TibiaFemurJointCavityCenter = (KneeJoint+{0.01, -0.018, 0.0})*.TF';
+    AnyVec3 TibiaTalusJointCavityCenter = (0.5*(MedialMalleolus+LateralMalleolus)+{0.01, 0.008, 0})*.TF';
+    
     AnyVec3 MedialTibialEpicondyle = {0, 0.321463224672736, -0.038645847149671}*.TF';
     AnyVec3 LateralTibialEpicondyle = {0, 0.319398338284877, 0.038645847149671}*.TF';
     AnyVec3 EpicondylusFemorisLateralis = {0.000370957510065,  0.360085611549568,   0.035632738850267}*.TF';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ You can [enable backwards compatibility](changes-to-muscles-locations) by settin
 * New muscles are added in the neck region. These include iliocostalis cervicis, longus colli superior and inferior obliques, and additional fibers
   for longus colli (T2C3, T2C2, T1C3, T1C2).
 
+* New reference nodes (`TibiaFemurJointCavityCenter` and `TibiaTalusJointCavityCenter`) are added on the shank to represent the center of the
+  joint cavity at knee and ankle.
+
 **Changed:**
 
 (changes-to-default-pelivs-morphology)=


### PR DESCRIPTION
This PR adds new reference nodes on the shank: 
New reference nodes (`TibiaFemurJointCavityCenter` and `TibiaTalusJointCavityCenter`) are added on the shank to represent the center of the joint cavity at knee and ankle.

Changelog is added