### PR TITLE
feat: Ab layer improvement

### DIFF
--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.any
@@ -89,7 +89,7 @@
 
 // Internal swtich to enable an inter-layer between L5 and pelvis. This layer allow anteroposterior movement.
 #ifndef BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC
-#define BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC OFF
+#define BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC ON
 #endif
 
 // Internal swtich to enable a recruited actuators on the rib end of floating ribs (rib11, rib12).

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.any
@@ -89,7 +89,7 @@
 
 // Internal swtich to enable an inter-layer between L5 and pelvis. This layer allow anteroposterior movement.
 #ifndef BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC
-#define BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC ON
+#define BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC OFF
 #endif
 
 // Internal swtich to enable a recruited actuators on the rib end of floating ribs (rib11, rib12).

--- a/Body/AAUHuman/Trunk/Abdominal/AbdominalPressureModel.any
+++ b/Body/AAUHuman/Trunk/Abdominal/AbdominalPressureModel.any
@@ -508,8 +508,8 @@ AnyFolder Abdominal = {
     #include "Layer.any"
 
    AnyFolder LayerConstraints ={
-        AnyVar K_top =2;
-        AnyVar K_bot =1;
+        AnyVar K_top =1;
+        AnyVar K_bot =10;
 
       
         #ifdef RECTUS_MUSCLE_LINE_CONTROL 
@@ -766,7 +766,7 @@ AnyFolder Abdominal = {
   
   
   AnyFolder Layer_Pelvic1 = {
-    AnyVar K_top =1;
+    AnyVar K_top =10;
     AnyVar K_bot =1;
     
     AnyFolder &Data = ...Trunk.Data.unscaled.ModelParameters.Abdominal.Layer_L5;
@@ -776,7 +776,9 @@ AnyFolder Abdominal = {
 
     BaseSegPosterior = {
       AnyRefNode Layer1 = {ARel = .AnatomicalFrameTrunk.ARel;};
+      AnyRefNode &JntNode1 = ....Trunk.Segments.PelvisSeg.PelvicLayer1_JntNode;
     };
+    AnyRefNode &JntNodeRef = BaseSegPosterior.JntNode1;
     AnyRefNode &LayerRef = BaseSegPosterior.Layer1;
     #if BM_TRUNK_EXPERIMENTAL_INTER_LAYER_L5PELVIC == OFF
     AnyFolder &layer_above = .Layer_L5;
@@ -815,8 +817,10 @@ AnyFolder Abdominal = {
     AnyFolder &Data =...Trunk.Data.unscaled.ModelParameters.Abdominal.Layer_Pelvic2; 
     AnySeg &BaseSegPosterior = .Layer_Pelvic1.BaseSegPosterior;   
     BaseSegPosterior ={
-    AnyRefNode Layer2 = {ARel = .AnatomicalFrameTrunk.ARel;};
+      AnyRefNode Layer2 = {ARel = .AnatomicalFrameTrunk.ARel;};
+      AnyRefNode &JntNode2 = ....Trunk.Segments.PelvisSeg.PelvicLayer2_JntNode;
     };
+    AnyRefNode &JntNodeRef = BaseSegPosterior.JntNode2;
     AnyRefNode &LayerRef = BaseSegPosterior.Layer2;
     AnyFolder &layer_above = .Layer_Pelvic1;
     AnyFolder &layer_below =  .Layer_Pelvic3; 
@@ -834,7 +838,9 @@ AnyFolder Abdominal = {
     AnySeg &BaseSegPosterior = .Layer_Pelvic1.BaseSegPosterior;   
     BaseSegPosterior ={
       AnyRefNode Layer3 = {ARel = .AnatomicalFrameTrunk.ARel;};
+      AnyRefNode &JntNode3 = ....Trunk.Segments.PelvisSeg.PelvicLayer3_JntNode;
     };
+    AnyRefNode &JntNodeRef = BaseSegPosterior.JntNode3;
     AnyRefNode &LayerRef = BaseSegPosterior.Layer3;
     AnyFolder &layer_above = .Layer_Pelvic2;
     AnyFolder &layer_below =  .Layer_Pelvic4; 

--- a/Body/AAUHuman/Trunk/Abdominal/AbdominalPressureModel.any
+++ b/Body/AAUHuman/Trunk/Abdominal/AbdominalPressureModel.any
@@ -1,7 +1,7 @@
 
 #define PELVIC_LAYER_MOVES
 #define RECTUS_MUSCLE_LINE_CONTROL
-#define INTER_LAYER_L1RIBCAGE
+//#define INTER_LAYER_L1RIBCAGE
 
 /// The abdominal model consists of a series of layers with individual volumes and pressure muscles
 AnyFolder Abdominal = {   

--- a/Body/AAUHuman/Trunk/Abdominal/InterLayer_L1Ribcage.any
+++ b/Body/AAUHuman/Trunk/Abdominal/InterLayer_L1Ribcage.any
@@ -37,6 +37,7 @@ AnyFolder Inter_Layer_L1Ribcage = {
       };
     };
     AnyRefNode Xiphoid_Diaphragm = {sRel = ...Diaphragm.CavitySeg.Xiphoid_Diaphragm.sRel;}; 
+    AnyRefNode &BaseSegPosterior_JntNode = ..Layer_L1.BaseSegPosterior.JntNode;
   };
   
   AnyFolder &Data =...Trunk.Data.unscaled.ModelParameters.Abdominal.Layer_L1;    

--- a/Body/AAUHuman/Trunk/Abdominal/InterLayer_PelvicL5.any
+++ b/Body/AAUHuman/Trunk/Abdominal/InterLayer_PelvicL5.any
@@ -40,6 +40,7 @@ AnyFolder Inter_Layer_PelvisL5 = {
       };
       
     };
+    AnyRefNode &BaseSegPosterior_JntNode = ..Layer_L5.BaseSegPosterior.JntNode;
   };
   
   

--- a/Body/AAUHuman/Trunk/Abdominal/Layer.any
+++ b/Body/AAUHuman/Trunk/Abdominal/Layer.any
@@ -136,6 +136,7 @@ AnySeg BaseSegAnterior = {
     AnyVec3 unscaled = 0.5 * (..Data.AbdominalCavityPoints.Right.Parametric.Fun(1.0) + ..Data.AbdominalCavityPoints.Left.Parametric.Fun(1.0));
     sRel = ..ScaleAndProjectToLayer(unscaled);
   };
+  AnyRefNode &BaseSegPosterior_JntNode = .BaseSegPosterior.JntNode;
   AnyRefNode rectus2R ={sRel= ..ScaleAndProjectToLayer(.mid.unscaled + {0,0,0.2*0.2});}; //front right
   AnyRefNode rectus2L ={sRel= ..ScaleAndProjectToLayer(.mid.unscaled + {0,0,-0.2*0.2});}; //front right
     

--- a/Body/AAUHuman/Trunk/Abdominal/LayerConstraints.any
+++ b/Body/AAUHuman/Trunk/Abdominal/LayerConstraints.any
@@ -281,7 +281,8 @@ AnyFolder SpringMeasures = {
 
 AnyKinEq RotationConstraint = {
   RigidBodyAverageMeasure CombinationMeasure(ROTATIONAL=On, LINEAR=On,POWER =3) = { 
-    LocalReferenceFrame = &...BaseSegAnterior.Origin;
+
+    LocalReferenceFrame = &...BaseSegAnterior.BaseSegPosterior_JntNode;
     InputMeasures = {
         &..SpringMeasures.Top.M1,
         &..SpringMeasures.Top.M2,

--- a/Body/AAUHuman/Trunk/Abdominal/LayerConstraintsPelvic.any
+++ b/Body/AAUHuman/Trunk/Abdominal/LayerConstraintsPelvic.any
@@ -136,17 +136,7 @@ AnyFolder LayerConstraints ={
       
     };
     
-    
-    
-    AnyKinLinear PelvicLayer_BaseSegAnterior = {
-      AnyRefNode &ref1 = ...LayerRef;
-      AnyRefFrame &ref2 = ...BaseSegAnterior.JntNode;  
-      Ref=0;             //AnyDrawPLine drw ={Thickness=0.0025;};
-    };
-    
-    
-    
-    
+
     
   };
   
@@ -155,7 +145,7 @@ AnyFolder LayerConstraints ={
   
   AnyKinEq RotationConstraint = {
     RigidBodyAverageMeasure CombinationMeasure(ROTATIONAL=On, LINEAR=On) = {
-      LocalReferenceFrame = &...BaseSegAnterior.Origin;
+      LocalReferenceFrame = &...BaseSegAnterior.JntNode;
       InputMeasures = {
         &..SpringMeasures.Top.M1,
         &..SpringMeasures.Top.M2,
@@ -181,13 +171,11 @@ AnyFolder LayerConstraints ={
         &..SpringMeasures.Bot.M10,
         &..SpringMeasures.Bot.M11,
         &..SpringMeasures.Bot.M12,
-        
-        &..SpringMeasures.PelvicLayer_BaseSegAnterior 
+
         
       };
       WeightCoefficients = {...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,...K_top,
         ...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,...K_bot,
-        1
       };
     };
     Reaction.Type = repmat(nDim, On);   //Note this is on becuase there are no muscles to carry this DOF

--- a/Body/AAUHuman/Trunk/Abdominal/Pelvic_Layer.any
+++ b/Body/AAUHuman/Trunk/Abdominal/Pelvic_Layer.any
@@ -39,7 +39,7 @@ AnySeg BaseSegAnterior={
   r0 = .BaseSegPosterior.r0;
   Axes0 = .BaseSegPosterior.Axes0;
   AnyRefNode Origin = {};
-  AnyRefNode JntNode = {sRel = ..LayerRef.sRel;};
+  AnyRefNode JntNode = {sRel=..JntNodeRef.sRel;};
   
   CavityPoints VolumePoints(data=..Data.AbdominalCavityPoints, scale_fun=..ScaleAndProjectToLayer) = {
     Right.points_generator = {
@@ -126,7 +126,7 @@ flip(LayerRef.VolumePoints.Left.NodePointers)
 #ifndef PELVIC_LAYER_MOVES
 
 AnyStdJoint PelvicLayer_BaseSegAnterior = {
-  AnyRefNode &ref1 = .LayerRef;
+  AnyRefNode &ref1 = .JntNodeRef;
   AnyRefFrame &ref2 = .BaseSegAnterior.JntNode;  
 };
 
@@ -142,7 +142,7 @@ AnyStdJoint PelvicLayer_BaseSegAnterior = {
 #ifndef RECTUS_MUSCLE_LINE_CONTROL 
 
 AnyRevoluteJoint PelvicLayer_BaseSegAnterior = {
-  AnyRefNode &ref1 = .LayerRef;
+  AnyRefNode &ref1 = .JntNodeRef;
   AnyRefFrame &ref2 = .BaseSegAnterior.JntNode;  
   Axis=z;
 };
@@ -151,13 +151,13 @@ AnyRevoluteJoint PelvicLayer_BaseSegAnterior = {
 AnyKinEq PelvicLayer_BaseSegAnterior_Constraints ={
    AnyKinMeasureOrg  dof={
     AnyKinLinear lin  ={
-      AnyRefNode &ref1 = ...LayerRef;
+      AnyRefNode &ref1 = ...JntNodeRef;
       AnyRefFrame &ref2 = ...BaseSegAnterior.JntNode;  
       Ref=0;
     };
     
     AnyKinRotational rot  ={
-      AnyRefNode &ref1 = ...LayerRef;
+      AnyRefNode &ref1 = ...JntNodeRef;
       AnyRefFrame &ref2 = ...BaseSegAnterior.JntNode;  
       Type=RotAxesAngles;
     };

--- a/Body/AAUHuman/Trunk/PelvisSeg.any
+++ b/Body/AAUHuman/Trunk/PelvisSeg.any
@@ -272,6 +272,9 @@ AnySeg PelvisSeg = {
   AnyRefNode GroundPelvisJntNode = {sRel = .Scale(.Data.GroundPelvisJntNode_pos);};
   AnyRefNode PelvisSacrumJntNode = {sRel = .Scale(.Data.PelvisSacrumJntNode_pos);};
   AnyRefNode Seat2MidContactNode={sRel=0.5*(.Right.Seat2ContactNode.sRel+.Left.Seat2ContactNode.sRel);}; 
+  AnyRefNode PelvicLayer1_JntNode={sRel=.Scale(.Data.PelvicLayer1_JntNode_pos);}; 
+  AnyRefNode PelvicLayer2_JntNode={sRel=.Scale(.Data.PelvicLayer2_JntNode_pos);}; 
+  AnyRefNode PelvicLayer3_JntNode={sRel=.Scale(.Data.PelvicLayer3_JntNode_pos);}; 
 
   /// The Right node is used by different body part for adding mirrored nodes
   /// (muscle origins/insertions etc) to the pelvis segment

--- a/Body/AAUHuman/Trunk/TrunkData1.1/LumbarNodes.any
+++ b/Body/AAUHuman/Trunk/TrunkData1.1/LumbarNodes.any
@@ -53,6 +53,10 @@ AnyFolder Pelvis = {
   AnyFloat RibConstraintsPelvisNodeR_pos = {0.035000, 0.1, 0.1};
   AnyFloat RibConstraintsPelvisNodeL_pos = {0.035000, 0.1, -0.1};
 
+  AnyFloat PelvicLayer1_JntNode_pos = {0.00212704, -0.01660388, 0.0};
+  AnyFloat PelvicLayer2_JntNode_pos = {0.00212704, -0.04607247, 0.0};
+  AnyFloat PelvicLayer3_JntNode_pos = {0.00212704, -0.08536393, 0.0};
+
   #if BM_TRUNK_CAVITY_MODEL == _CAVITY_MODEL_VOLUME_
       AnyFloat BuckleNodeBottomCenter_pos =0.5*(Right.BuckleNode_pos+Left.BuckleNode_pos);
   #else


### PR DESCRIPTION
Fix bug LocalReferenceFrame to be layer joint nodes. This made huge improvement in ROM.
New joint nodes for pelvic layers since they did not have any.
Now we can play with the weights since we have correct LocalReferenceFrame in the averaging measures.
Update Weights in averaging measure handling layers
 to move better and avoid layers from crisscrossing.
Disable both Inter_Layers (bottom and top)
Fix pelvis volume kink by adding a dummy segment and following a new line
Remove layer4 from Pelvis volume to avoid kink since layer4 is not moving.
