### PR TITLE
fix: Fix muscle lists in calibration study for new muscle component tree

### DIFF
--- a/Body/AAUHuman/Arm/Calibration/ArmCal0.any
+++ b/Body/AAUHuman/Arm/Calibration/ArmCal0.any
@@ -228,8 +228,8 @@ AnyFolder ArmCal0 ={
   
   
   AnyObjectPtrArray all_arm_muscles  = arrcat(
-  ObjSearch(CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles)+".*", "AnyMuscleViaPoint"),
-  ObjSearch(CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles)+".*", "AnyMuscleShortestPath")
+  ObjSearch(CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles)+".*.*", "AnyMuscleViaPoint"),
+  ObjSearch(CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles)+".*.*", "AnyMuscleShortestPath")
    );
 
 };

--- a/Body/AAUHuman/Arm/Calibration/ArmCal1.any
+++ b/Body/AAUHuman/Arm/Calibration/ArmCal1.any
@@ -257,7 +257,7 @@ AnyBodyCalibrationStudy ArmCalibrationStudy1 = {
   AnyFolder &ref=.ArmCal1;
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
-  MuscleArr = ObjSearch(MusPrefix+".deltoideus_posterior_*", "AnyMuscle"); 
+  MuscleArr = ObjSearch(MusPrefix+".*.deltoideus_posterior_*", "AnyMuscle"); 
   
   nStep = 1;
   Kinematics.KinematicTol = 1e-07;

--- a/Body/AAUHuman/Arm/Calibration/ArmCal2.any
+++ b/Body/AAUHuman/Arm/Calibration/ArmCal2.any
@@ -237,9 +237,9 @@ AnyFolder ArmCal2 ={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   #if BM_ARM_DELTOID_WRAPPING == _DELTOID_WRAPPING_RAKE_
-  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".deltoideus_clavicular*", "AnyMuscle");
+  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".*.deltoideus_clavicular*", "AnyMuscle");
   #else
-  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".deltoideus_anterior*", "AnyMuscle");
+  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".*.deltoideus_anterior*", "AnyMuscle");
   #endif
   
 };

--- a/Body/AAUHuman/Arm/Calibration/ArmCal3.any
+++ b/Body/AAUHuman/Arm/Calibration/ArmCal3.any
@@ -248,11 +248,11 @@ AnyFolder ArmCal3 ={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   
-  AnyObjectPtrArray biceps_brachiiMuscles = ObjSearch(MusPrefix+".biceps_brachii*", "AnyMuscle");
-  AnyObjectPtrArray pectoralis_major_clavicularMuscles = ObjSearch(MusPrefix+".pectoralis_major_clavicular*", "AnyMuscle");
-  AnyObjectPtrArray pectoralis_major_thoracicMuscles = ObjSearch(MusPrefix+".pectoralis_major_thoracic*", "AnyMuscle");
-  AnyObjectPtrArray teres_majorMuscles = ObjSearch(MusPrefix+".teres_major*", "AnyMuscle");
-  AnyObjectPtrArray teres_minorMuscles = ObjSearch(MusPrefix+".teres_minor*", "AnyMuscle");
+  AnyObjectPtrArray biceps_brachiiMuscles = ObjSearch(MusPrefix+".*.biceps_brachii*", "AnyMuscle");
+  AnyObjectPtrArray pectoralis_major_clavicularMuscles = ObjSearch(MusPrefix+".*.pectoralis_major_clavicular*", "AnyMuscle");
+  AnyObjectPtrArray pectoralis_major_thoracicMuscles = ObjSearch(MusPrefix+".*.pectoralis_major_thoracic*", "AnyMuscle");
+  AnyObjectPtrArray teres_majorMuscles = ObjSearch(MusPrefix+".*.teres_major*", "AnyMuscle");
+  AnyObjectPtrArray teres_minorMuscles = ObjSearch(MusPrefix+".*.teres_minor*", "AnyMuscle");
   
 };
 

--- a/Body/AAUHuman/Arm/Calibration/ArmCal4.any
+++ b/Body/AAUHuman/Arm/Calibration/ArmCal4.any
@@ -237,9 +237,9 @@ AnyFolder ArmCal4 ={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   
-  AnyObjectPtrArray supraspinatusMuscles = ObjSearch(MusPrefix+".supraspinatus*", "AnyMuscle");
-  AnyObjectPtrArray infraspinatusMuscles = ObjSearch(MusPrefix+".infraspinatus*", "AnyMuscle");
-  AnyObjectPtrArray TricepsMuscles = ObjSearch(MusPrefix+".Triceps*", "AnyMuscle");
+  AnyObjectPtrArray supraspinatusMuscles = ObjSearch(MusPrefix+".*.supraspinatus*", "AnyMuscle");
+  AnyObjectPtrArray infraspinatusMuscles = ObjSearch(MusPrefix+".*.infraspinatus*", "AnyMuscle");
+  AnyObjectPtrArray TricepsMuscles = ObjSearch(MusPrefix+".*.Triceps*", "AnyMuscle");
   
 };
 

--- a/Body/AAUHuman/Arm/Calibration/ArmCal5.any
+++ b/Body/AAUHuman/Arm/Calibration/ArmCal5.any
@@ -245,7 +245,7 @@ AnyFolder ArmCal5 ={
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
 
 
-   AnyObjectPtrArray latissimus_dorsi_Muscles = ObjSearch(MusPrefix+".latissimus_dorsi_*", "AnyMuscle");
+   AnyObjectPtrArray latissimus_dorsi_Muscles = ObjSearch(MusPrefix+".*.latissimus_dorsi_*", "AnyMuscle");
 
 };
 

--- a/Body/AAUHuman/Arm/Calibration/ElbowCal.any
+++ b/Body/AAUHuman/Arm/Calibration/ElbowCal.any
@@ -256,47 +256,47 @@ AnyFolder ElbowCal ={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   
-  AnyObjectPtrArray biceps_brachii_caput_breveMuscles = ObjSearch(MusPrefix+".biceps_brachii_caput_breve*", "AnyMuscle");
+  AnyObjectPtrArray biceps_brachii_caput_breveMuscles = ObjSearch(MusPrefix+".*.biceps_brachii_caput_breve*", "AnyMuscle");
   AnyFloat  biceps_brachii_caput_breveRmin = repmat(NumElemOf(biceps_brachii_caput_breveMuscles), ..RMin);
   AnyFloat  biceps_brachii_caput_breveRmax = repmat(NumElemOf(biceps_brachii_caput_breveMuscles), ..RMax);
 
-  AnyObjectPtrArray biceps_brachii_caput_longumMuscles = ObjSearch(MusPrefix+".biceps_brachii_caput_longum*", "AnyMuscle");
+  AnyObjectPtrArray biceps_brachii_caput_longumMuscles = ObjSearch(MusPrefix+".*.biceps_brachii_caput_longum*", "AnyMuscle");
   AnyFloat  biceps_brachii_caput_longumRmin = repmat(NumElemOf(biceps_brachii_caput_longumMuscles), ..RMin);
   AnyFloat  biceps_brachii_caput_longumRmax = repmat(NumElemOf(biceps_brachii_caput_longumMuscles), ..RMax);
 
-  AnyObjectPtrArray BrachialisMuscles = ObjSearch(MusPrefix+".Brachialis*", "AnyMuscle");
+  AnyObjectPtrArray BrachialisMuscles = ObjSearch(MusPrefix+".*.Brachialis*", "AnyMuscle");
   AnyFloat  BrachialisRmin = repmat(NumElemOf(BrachialisMuscles), ..RMin);
   AnyFloat  BrachialisRmax = repmat(NumElemOf(BrachialisMuscles), ..RMax);
 
-  AnyObjectPtrArray TricepsMuscles = ObjSearch(MusPrefix+".Triceps*", "AnyMuscle");
+  AnyObjectPtrArray TricepsMuscles = ObjSearch(MusPrefix+".*.Triceps*", "AnyMuscle");
   AnyFloat  TricepsRmin = repmat(NumElemOf(TricepsMuscles), ..RMin);
   AnyFloat  TricepsRmax = repmat(NumElemOf(TricepsMuscles), ..RMax);
 
-  AnyObjectPtrArray Brach_radMuscles = ObjSearch(MusPrefix+".Brach_rad*", "AnyMuscle");
+  AnyObjectPtrArray Brach_radMuscles = ObjSearch(MusPrefix+".*.Brach_rad*", "AnyMuscle");
   AnyFloat  Brach_radRmin = repmat(NumElemOf(Brach_radMuscles), ..RMin);
   AnyFloat  Brach_radRmax = repmat(NumElemOf(Brach_radMuscles), ..RMax);
 
-  AnyObjectPtrArray AnconeusMuscles = ObjSearch(MusPrefix+".Anconeus*", "AnyMuscle");
+  AnyObjectPtrArray AnconeusMuscles = ObjSearch(MusPrefix+".*.Anconeus*", "AnyMuscle");
   AnyFloat  AnconeusRmin = repmat(NumElemOf(AnconeusMuscles), ..RMin);
   AnyFloat  AnconeusRmax = repmat(NumElemOf(AnconeusMuscles), ..RMax);
 
-  AnyObjectPtrArray Pronator_teres_caput_humeralMuscles = ObjSearch(MusPrefix+".Pronator_teres_caput_humeral*", "AnyMuscle");
+  AnyObjectPtrArray Pronator_teres_caput_humeralMuscles = ObjSearch(MusPrefix+".*.Pronator_teres_caput_humeral*", "AnyMuscle");
   AnyFloat  Pronator_teres_caput_humeralRmin = repmat(NumElemOf(Pronator_teres_caput_humeralMuscles), ..RMin);
   AnyFloat  Pronator_teres_caput_humeralRmax = repmat(NumElemOf(Pronator_teres_caput_humeralMuscles), ..RMax);
 
-  AnyObjectPtrArray Pronator_teres_caput_ulnareMuscles = ObjSearch(MusPrefix+".Pronator_teres_caput_ulnare*", "AnyMuscle");
+  AnyObjectPtrArray Pronator_teres_caput_ulnareMuscles = ObjSearch(MusPrefix+".*.Pronator_teres_caput_ulnare*", "AnyMuscle");
   AnyFloat  Pronator_teres_caput_ulnareRmin = repmat(NumElemOf(Pronator_teres_caput_ulnareMuscles), ..RMin);
   AnyFloat  Pronator_teres_caput_ulnareRmax = repmat(NumElemOf(Pronator_teres_caput_ulnareMuscles), ..RMax);
 
-  AnyObjectPtrArray Supinator_humerusMuscles = ObjSearch(MusPrefix+".Supinator_humerus*", "AnyMuscle");
+  AnyObjectPtrArray Supinator_humerusMuscles = ObjSearch(MusPrefix+".*.Supinator_humerus*", "AnyMuscle");
   AnyFloat  Supinator_humerusRmin = repmat(NumElemOf(Supinator_humerusMuscles), ..RMin);
   AnyFloat  Supinator_humerusRmax = repmat(NumElemOf(Supinator_humerusMuscles), ..RMax);
 
-  AnyObjectPtrArray Supinator_ulnaMuscles = ObjSearch(MusPrefix+".Supinator_ulna*", "AnyMuscle");
+  AnyObjectPtrArray Supinator_ulnaMuscles = ObjSearch(MusPrefix+".*.Supinator_ulna*", "AnyMuscle");
   AnyFloat  Supinator_ulnaRmin = repmat(NumElemOf(Supinator_ulnaMuscles), ..RMin);
   AnyFloat  Supinator_ulnaRmax = repmat(NumElemOf(Supinator_ulnaMuscles), ..RMax);
 
-  AnyObjectPtrArray Pron_quadrMuscles = ObjSearch(MusPrefix+".Pron_quadr*", "AnyMuscle");
+  AnyObjectPtrArray Pron_quadrMuscles = ObjSearch(MusPrefix+".*.Pron_quadr*", "AnyMuscle");
   AnyFloat  Pron_quadrRmin = repmat(NumElemOf(Pron_quadrMuscles), ..RMin);
   AnyFloat  Pron_quadrRmax = repmat(NumElemOf(Pron_quadrMuscles), ..RMax);
   

--- a/Body/AAUHuman/Arm/Calibration/ShoulderCal.any
+++ b/Body/AAUHuman/Arm/Calibration/ShoulderCal.any
@@ -257,70 +257,70 @@ AnyFolder ShoulderCal ={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   
-  AnyObjectPtrArray coracobrachialisMuscles = ObjSearch(MusPrefix+".coracobrachialis*", "AnyMuscle");
+  AnyObjectPtrArray coracobrachialisMuscles = ObjSearch(MusPrefix+".*.coracobrachialis*", "AnyMuscle");
   AnyFloat  coracobrachialisRmin = repmat(NumElemOf(coracobrachialisMuscles), ..RMin);
   AnyFloat  coracobrachialisRmax = repmat(NumElemOf(coracobrachialisMuscles), ..RMax);
   
   #if BM_ARM_DELTOID_WRAPPING == _DELTOID_WRAPPING_RAKE_
-  AnyObjectPtrArray deltoideus_scapularMuscles = ObjSearch(MusPrefix+".deltoideus_scapular*", "AnyMuscle");
+  AnyObjectPtrArray deltoideus_scapularMuscles = ObjSearch(MusPrefix+".*.deltoideus_scapular*", "AnyMuscle");
   #else
   AnyObjectPtrArray deltoideus_scapularMuscles = arrcat(
-    ObjSearch(MusPrefix+".deltoideus_posterior*", "AnyMuscle"),
-    ObjSearch(MusPrefix+".deltoideus_lateral*", "AnyMuscle")
+    ObjSearch(MusPrefix+".*.deltoideus_posterior*", "AnyMuscle"),
+    ObjSearch(MusPrefix+".*.deltoideus_lateral*", "AnyMuscle")
   );
   #endif
   AnyFloat  deltoideus_scapularRmin = repmat(NumElemOf(deltoideus_scapularMuscles), ..RMin);
   AnyFloat  deltoideus_scapularRmax = repmat(NumElemOf(deltoideus_scapularMuscles), ..RMax);
   
   #if BM_ARM_DELTOID_WRAPPING == _DELTOID_WRAPPING_RAKE_
-  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".deltoideus_clavicular*", "AnyMuscle");
+  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".*.deltoideus_clavicular*", "AnyMuscle");
   #else
-  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".deltoideus_anterior*", "AnyMuscle");
+  AnyObjectPtrArray deltoideus_clavicularMuscles = ObjSearch(MusPrefix+".*.deltoideus_anterior*", "AnyMuscle");
   #endif
   AnyFloat  deltoideus_clavicularRmin = repmat(NumElemOf(deltoideus_clavicularMuscles), ..RMin);
   AnyFloat  deltoideus_clavicularRmax = repmat(NumElemOf(deltoideus_clavicularMuscles), ..RMax);
   
-  AnyObjectPtrArray infraspinatusMuscles = ObjSearch(MusPrefix+".infraspinatus*", "AnyMuscle");
+  AnyObjectPtrArray infraspinatusMuscles = ObjSearch(MusPrefix+".*.infraspinatus*", "AnyMuscle");
   AnyFloat  infraspinatusRmin = repmat(NumElemOf(infraspinatusMuscles), ..RMin);
   AnyFloat  infraspinatusRmax = repmat(NumElemOf(infraspinatusMuscles), ..RMax);
   
-  AnyObjectPtrArray pectoralis_major_thoracicMuscles = ObjSearch(MusPrefix+".pectoralis_major_thoracic*", "AnyMuscle");
+  AnyObjectPtrArray pectoralis_major_thoracicMuscles = ObjSearch(MusPrefix+".*.pectoralis_major_thoracic*", "AnyMuscle");
   AnyFloat  pectoralis_major_thoracicRmin = repmat(NumElemOf(pectoralis_major_thoracicMuscles), ..RMin);
   AnyFloat  pectoralis_major_thoracicRmax = repmat(NumElemOf(pectoralis_major_thoracicMuscles), ..RMax);
   
-  AnyObjectPtrArray pectoralis_major_clavicularMuscles = ObjSearch(MusPrefix+".pectoralis_major_clavicular*", "AnyMuscle");
+  AnyObjectPtrArray pectoralis_major_clavicularMuscles = ObjSearch(MusPrefix+".*.pectoralis_major_clavicular*", "AnyMuscle");
   AnyFloat  pectoralis_major_clavicularRmin = repmat(NumElemOf(pectoralis_major_clavicularMuscles), ..RMin);
   AnyFloat  pectoralis_major_clavicularRmax = repmat(NumElemOf(pectoralis_major_clavicularMuscles), ..RMax);
   
-  AnyObjectPtrArray pectoralis_minorMuscles = ObjSearch(MusPrefix+".pectoralis_minor*", "AnyMuscle");
+  AnyObjectPtrArray pectoralis_minorMuscles = ObjSearch(MusPrefix+".*.pectoralis_minor*", "AnyMuscle");
   AnyFloat  pectoralis_minorRmin = repmat(NumElemOf(pectoralis_minorMuscles), ..RMin);
   AnyFloat  pectoralis_minorRmax = repmat(NumElemOf(pectoralis_minorMuscles), ..RMax);
   
-  AnyObjectPtrArray rhomboideusMuscles = ObjSearch(MusPrefix+".rhomboideus*", "AnyMuscle");
+  AnyObjectPtrArray rhomboideusMuscles = ObjSearch(MusPrefix+".*.rhomboideus*", "AnyMuscle");
   AnyFloat  rhomboideusRmin = repmat(NumElemOf(rhomboideusMuscles), ..RMin);
   AnyFloat  rhomboideusRmax = repmat(NumElemOf(rhomboideusMuscles), ..RMax);
   
-  AnyObjectPtrArray serratus_anteriorMuscles = ObjSearch(MusPrefix+".serratus_anterior*", "AnyMuscle");
+  AnyObjectPtrArray serratus_anteriorMuscles = ObjSearch(MusPrefix+".*.serratus_anterior*", "AnyMuscle");
   AnyFloat  serratus_anteriorRmin = repmat(NumElemOf(serratus_anteriorMuscles), ..RMin);
   AnyFloat  serratus_anteriorRmax = repmat(NumElemOf(serratus_anteriorMuscles), ..RMax);
   
-  AnyObjectPtrArray subscapularisMuscles = ObjSearch(MusPrefix+".subscapularis*", "AnyMuscle");
+  AnyObjectPtrArray subscapularisMuscles = ObjSearch(MusPrefix+".*.subscapularis*", "AnyMuscle");
   AnyFloat  subscapularisRmin = repmat(NumElemOf(subscapularisMuscles), ..RMin);
   AnyFloat  subscapularisRmax = repmat(NumElemOf(subscapularisMuscles), ..RMax);
   
-  AnyObjectPtrArray supraspinatusMuscles = ObjSearch(MusPrefix+".supraspinatus*", "AnyMuscle");
+  AnyObjectPtrArray supraspinatusMuscles = ObjSearch(MusPrefix+".*.supraspinatus*", "AnyMuscle");
   AnyFloat  supraspinatusRmin = repmat(NumElemOf(supraspinatusMuscles), ..RMin);
   AnyFloat  supraspinatusRmax = repmat(NumElemOf(supraspinatusMuscles), ..RMax);
   
-  AnyObjectPtrArray teres_majorMuscles = ObjSearch(MusPrefix+".teres_major*", "AnyMuscle");
+  AnyObjectPtrArray teres_majorMuscles = ObjSearch(MusPrefix+".*.teres_major*", "AnyMuscle");
   AnyFloat  teres_majorRmin = repmat(NumElemOf(teres_majorMuscles), ..RMin);
   AnyFloat  teres_majorRmax = repmat(NumElemOf(teres_majorMuscles), ..RMax);
   
-  AnyObjectPtrArray teres_minorMuscles = ObjSearch(MusPrefix+".teres_minor*", "AnyMuscle");
+  AnyObjectPtrArray teres_minorMuscles = ObjSearch(MusPrefix+".*.teres_minor*", "AnyMuscle");
   AnyFloat  teres_minorRmin = repmat(NumElemOf(teres_minorMuscles), ..RMin);
   AnyFloat  teres_minorRmax = repmat(NumElemOf(teres_minorMuscles), ..RMax);
   
-  AnyObjectPtrArray trapezius_scapularMuscles = ObjSearch(MusPrefix+".trapezius_scapular*", "AnyMuscle");
+  AnyObjectPtrArray trapezius_scapularMuscles = ObjSearch(MusPrefix+".*.trapezius_scapular*", "AnyMuscle");
   AnyFloat  trapezius_scapularRmin = repmat(NumElemOf(trapezius_scapularMuscles), ..RMin);
   AnyFloat  trapezius_scapularRmax = repmat(NumElemOf(trapezius_scapularMuscles), ..RMax);
   

--- a/Body/AAUHuman/Arm/Calibration/SpineDependentCal.any
+++ b/Body/AAUHuman/Arm/Calibration/SpineDependentCal.any
@@ -269,19 +269,19 @@ AnyFolder SpineDependentCal ={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   
-  AnyObjectPtrArray levator_scapulaeMuscles = ObjSearch(MusPrefix+".levator_scapulae*", "AnyMuscle");
+  AnyObjectPtrArray levator_scapulaeMuscles = ObjSearch(MusPrefix+".*.levator_scapulae*", "AnyMuscle");
   AnyFloat  levator_scapulaeRmin = repmat(NumElemOf(levator_scapulaeMuscles), ..RMin);
   AnyFloat  levator_scapulaeRmax = repmat(NumElemOf(levator_scapulaeMuscles), ..RMax);
 
-  AnyObjectPtrArray trapezius_clavicularMuscles = ObjSearch(MusPrefix+".trapezius_clavicular*", "AnyMuscle");
+  AnyObjectPtrArray trapezius_clavicularMuscles = ObjSearch(MusPrefix+".*.trapezius_clavicular*", "AnyMuscle");
   AnyFloat  trapezius_clavicularRmin = repmat(NumElemOf(trapezius_clavicularMuscles), ..RMin);
   AnyFloat  trapezius_clavicularRmax = repmat(NumElemOf(trapezius_clavicularMuscles), ..RMax);
 
-  AnyObjectPtrArray SternocleidomastoidMuscles = ObjSearch(MusPrefix+".Sternocleidomastoid*", "AnyMuscle");
+  AnyObjectPtrArray SternocleidomastoidMuscles = ObjSearch(MusPrefix+".*.Sternocleidomastoid*", "AnyMuscle");
   AnyFloat  SternocleidomastoidRmin = repmat(NumElemOf(SternocleidomastoidMuscles), ..RMin);
   AnyFloat  SternocleidomastoidRmax = repmat(NumElemOf(SternocleidomastoidMuscles), ..RMax);
 
-  AnyObjectPtrArray latissimus_dorsiMuscles = ObjSearch(MusPrefix+".latissimus_dorsi*", "AnyMuscle");
+  AnyObjectPtrArray latissimus_dorsiMuscles = ObjSearch(MusPrefix+".*.latissimus_dorsi*", "AnyMuscle");
   AnyFloat  latissimus_dorsiRmin = repmat(NumElemOf(latissimus_dorsiMuscles), ..RMin);
   AnyFloat  latissimus_dorsiRmax = repmat(NumElemOf(latissimus_dorsiMuscles), ..RMax);
   

--- a/Body/AAUHuman/Arm/Calibration/WristCal.any
+++ b/Body/AAUHuman/Arm/Calibration/WristCal.any
@@ -244,47 +244,47 @@ AnyFolder WristCal ={
   
 AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.ShoulderArm.Muscles);
   
-  AnyObjectPtrArray biceps_brachii_caput_breveMuscles = ObjSearch(MusPrefix+".biceps_brachii_caput_breve*", "AnyMuscle");
+  AnyObjectPtrArray biceps_brachii_caput_breveMuscles = ObjSearch(MusPrefix+".*.biceps_brachii_caput_breve*", "AnyMuscle");
   AnyFloat  biceps_brachii_caput_breveRmin = repmat(NumElemOf(biceps_brachii_caput_breveMuscles), ..RMin);
   AnyFloat  biceps_brachii_caput_breveRmax = repmat(NumElemOf(biceps_brachii_caput_breveMuscles), ..RMax);
 
-  AnyObjectPtrArray biceps_brachii_caput_longumMuscles = ObjSearch(MusPrefix+".biceps_brachii_caput_longum*", "AnyMuscle");
+  AnyObjectPtrArray biceps_brachii_caput_longumMuscles = ObjSearch(MusPrefix+".*.biceps_brachii_caput_longum*", "AnyMuscle");
   AnyFloat  biceps_brachii_caput_longumRmin = repmat(NumElemOf(biceps_brachii_caput_longumMuscles), ..RMin);
   AnyFloat  biceps_brachii_caput_longumRmax = repmat(NumElemOf(biceps_brachii_caput_longumMuscles), ..RMax);
 
-  AnyObjectPtrArray BrachialisMuscles = ObjSearch(MusPrefix+".Brachialis*", "AnyMuscle");
+  AnyObjectPtrArray BrachialisMuscles = ObjSearch(MusPrefix+".*.Brachialis*", "AnyMuscle");
   AnyFloat  BrachialisRmin = repmat(NumElemOf(BrachialisMuscles), ..RMin);
   AnyFloat  BrachialisRmax = repmat(NumElemOf(BrachialisMuscles), ..RMax);
 
-  AnyObjectPtrArray TricepsMuscles = ObjSearch(MusPrefix+".Triceps*", "AnyMuscle");
+  AnyObjectPtrArray TricepsMuscles = ObjSearch(MusPrefix+".*.Triceps*", "AnyMuscle");
   AnyFloat  TricepsRmin = repmat(NumElemOf(TricepsMuscles), ..RMin);
   AnyFloat  TricepsRmax = repmat(NumElemOf(TricepsMuscles), ..RMax);
 
-  AnyObjectPtrArray Brach_radMuscles = ObjSearch(MusPrefix+".Brach_rad*", "AnyMuscle");
+  AnyObjectPtrArray Brach_radMuscles = ObjSearch(MusPrefix+".*.Brach_rad*", "AnyMuscle");
   AnyFloat  Brach_radRmin = repmat(NumElemOf(Brach_radMuscles), ..RMin);
   AnyFloat  Brach_radRmax = repmat(NumElemOf(Brach_radMuscles), ..RMax);
 
-  AnyObjectPtrArray AnconeusMuscles = ObjSearch(MusPrefix+".Anconeus*", "AnyMuscle");
+  AnyObjectPtrArray AnconeusMuscles = ObjSearch(MusPrefix+".*.Anconeus*", "AnyMuscle");
   AnyFloat  AnconeusRmin = repmat(NumElemOf(AnconeusMuscles), ..RMin);
   AnyFloat  AnconeusRmax = repmat(NumElemOf(AnconeusMuscles), ..RMax);
 
-  AnyObjectPtrArray Pronator_teres_caput_humeralMuscles = ObjSearch(MusPrefix+".Pronator_teres_caput_humeral*", "AnyMuscle");
+  AnyObjectPtrArray Pronator_teres_caput_humeralMuscles = ObjSearch(MusPrefix+".*.Pronator_teres_caput_humeral*", "AnyMuscle");
   AnyFloat  Pronator_teres_caput_humeralRmin = repmat(NumElemOf(Pronator_teres_caput_humeralMuscles), ..RMin);
   AnyFloat  Pronator_teres_caput_humeralRmax = repmat(NumElemOf(Pronator_teres_caput_humeralMuscles), ..RMax);
 
-  AnyObjectPtrArray Pronator_teres_caput_ulnareMuscles = ObjSearch(MusPrefix+".Pronator_teres_caput_ulnare*", "AnyMuscle");
+  AnyObjectPtrArray Pronator_teres_caput_ulnareMuscles = ObjSearch(MusPrefix+".*.Pronator_teres_caput_ulnare*", "AnyMuscle");
   AnyFloat  Pronator_teres_caput_ulnareRmin = repmat(NumElemOf(Pronator_teres_caput_ulnareMuscles), ..RMin);
   AnyFloat  Pronator_teres_caput_ulnareRmax = repmat(NumElemOf(Pronator_teres_caput_ulnareMuscles), ..RMax);
 
-  AnyObjectPtrArray Supinator_humerusMuscles = ObjSearch(MusPrefix+".Supinator_humerus*", "AnyMuscle");
+  AnyObjectPtrArray Supinator_humerusMuscles = ObjSearch(MusPrefix+".*.Supinator_humerus*", "AnyMuscle");
   AnyFloat  Supinator_humerusRmin = repmat(NumElemOf(Supinator_humerusMuscles), ..RMin);
   AnyFloat  Supinator_humerusRmax = repmat(NumElemOf(Supinator_humerusMuscles), ..RMax);
 
-  AnyObjectPtrArray Supinator_ulnaMuscles = ObjSearch(MusPrefix+".Supinator_ulna*", "AnyMuscle");
+  AnyObjectPtrArray Supinator_ulnaMuscles = ObjSearch(MusPrefix+".*.Supinator_ulna*", "AnyMuscle");
   AnyFloat  Supinator_ulnaRmin = repmat(NumElemOf(Supinator_ulnaMuscles), ..RMin);
   AnyFloat  Supinator_ulnaRmax = repmat(NumElemOf(Supinator_ulnaMuscles), ..RMax);
 
-  AnyObjectPtrArray Pron_quadrMuscles = ObjSearch(MusPrefix+".Pron_quadr*", "AnyMuscle");
+  AnyObjectPtrArray Pron_quadrMuscles = ObjSearch(MusPrefix+".*.Pron_quadr*", "AnyMuscle");
   AnyFloat  Pron_quadrRmin = repmat(NumElemOf(Pron_quadrMuscles), ..RMin);
   AnyFloat  Pron_quadrRmax = repmat(NumElemOf(Pron_quadrMuscles), ..RMax);
   

--- a/Body/AAUHuman/LegTLEM/Calibration/AnkleMuscleCal.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/AnkleMuscleCal.any
@@ -122,52 +122,52 @@ AnyFolder LegCalAnkle =
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray TibialisAnteriorMuscles = ObjSearch(MusPrefix+".TibialisAnterior*", "AnyMuscle");
+  AnyObjectPtrArray TibialisAnteriorMuscles = ObjSearch(MusPrefix+".*.TibialisAnterior*", "AnyMuscle");
   AnyFloat  TibialisAnteriorRmin = repmat(NumElemOf(TibialisAnteriorMuscles), ..RMin);
   AnyFloat  TibialisAnteriorRmax = repmat(NumElemOf(TibialisAnteriorMuscles), ..RMax);
   
-  AnyObjectPtrArray ExtensorDigitorumLongusMuscles = ObjSearch(MusPrefix+".ExtensorDigitorumLongus*", "AnyMuscle");
+  AnyObjectPtrArray ExtensorDigitorumLongusMuscles = ObjSearch(MusPrefix+".*.ExtensorDigitorumLongus*", "AnyMuscle");
   AnyFloat  ExtensorDigitorumLongusRmin = repmat(NumElemOf(ExtensorDigitorumLongusMuscles), ..RMin);
   AnyFloat  ExtensorDigitorumLongusRmax = repmat(NumElemOf(ExtensorDigitorumLongusMuscles), ..RMax);
   
-  AnyObjectPtrArray ExtensorHallucisLongusMuscles = ObjSearch(MusPrefix+".ExtensorHallucisLongus*", "AnyMuscle");
+  AnyObjectPtrArray ExtensorHallucisLongusMuscles = ObjSearch(MusPrefix+".*.ExtensorHallucisLongus*", "AnyMuscle");
   AnyFloat  ExtensorHallucisLongusRmin = repmat(NumElemOf(ExtensorHallucisLongusMuscles), ..RMin);
   AnyFloat  ExtensorHallucisLongusRmax = repmat(NumElemOf(ExtensorHallucisLongusMuscles), ..RMax);
 
-  AnyObjectPtrArray SoleusMuscles = ObjSearch(MusPrefix+".Soleus*", "AnyMuscle");
+  AnyObjectPtrArray SoleusMuscles = ObjSearch(MusPrefix+".*.Soleus*", "AnyMuscle");
   AnyFloat  SoleusRmin = repmat(NumElemOf(SoleusMuscles), ..RMin);
   AnyFloat  SoleusRmax = repmat(NumElemOf(SoleusMuscles), ..RMax);
   
-  AnyObjectPtrArray TibialisPosteriorMuscles = ObjSearch(MusPrefix+".TibialisPosterior*", "AnyMuscle");
+  AnyObjectPtrArray TibialisPosteriorMuscles = ObjSearch(MusPrefix+".*.TibialisPosterior*", "AnyMuscle");
   AnyFloat  TibialisPosteriorRmin = repmat(NumElemOf(TibialisPosteriorMuscles), ..RMin);
   AnyFloat  TibialisPosteriorRmax = repmat(NumElemOf(TibialisPosteriorMuscles), ..RMax);
   
-  AnyObjectPtrArray FlexorDigitorumLongusMuscles = ObjSearch(MusPrefix+".FlexorDigitorumLongus*", "AnyMuscle");
+  AnyObjectPtrArray FlexorDigitorumLongusMuscles = ObjSearch(MusPrefix+".*.FlexorDigitorumLongus*", "AnyMuscle");
   AnyFloat  FlexorDigitorumLongusRmin = repmat(NumElemOf(FlexorDigitorumLongusMuscles), ..RMin);
   AnyFloat  FlexorDigitorumLongusRmax = repmat(NumElemOf(FlexorDigitorumLongusMuscles), ..RMax);
 
-  AnyObjectPtrArray FlexorHallucisLongusMuscles = ObjSearch(MusPrefix+".FlexorHallucisLongus*", "AnyMuscle");
+  AnyObjectPtrArray FlexorHallucisLongusMuscles = ObjSearch(MusPrefix+".*.FlexorHallucisLongus*", "AnyMuscle");
   AnyFloat  FlexorHallucisLongusRmin = repmat(NumElemOf(FlexorHallucisLongusMuscles), ..RMin);
   AnyFloat  FlexorHallucisLongusRmax = repmat(NumElemOf(FlexorHallucisLongusMuscles), ..RMax);
   
-  AnyObjectPtrArray PeroneusBrevisMuscles = ObjSearch(MusPrefix+".PeroneusBrevis*", "AnyMuscle");
+  AnyObjectPtrArray PeroneusBrevisMuscles = ObjSearch(MusPrefix+".*.PeroneusBrevis*", "AnyMuscle");
   AnyFloat  PeroneusBrevisRmin = repmat(NumElemOf(PeroneusBrevisMuscles), ..RMin);
   AnyFloat  PeroneusBrevisRmax = repmat(NumElemOf(PeroneusBrevisMuscles), ..RMax);
   
-  AnyObjectPtrArray PeroneusLongusMuscles = ObjSearch(MusPrefix+".PeroneusLongus*", "AnyMuscle");
+  AnyObjectPtrArray PeroneusLongusMuscles = ObjSearch(MusPrefix+".*.PeroneusLongus*", "AnyMuscle");
   AnyFloat  PeroneusLongusRmin = repmat(NumElemOf(PeroneusLongusMuscles), ..RMin);
   AnyFloat  PeroneusLongusRmax = repmat(NumElemOf(PeroneusLongusMuscles), ..RMax);
   
-  AnyObjectPtrArray PeroneusTertiusMuscles = ObjSearch(MusPrefix+".PeroneusTertius*", "AnyMuscle");
+  AnyObjectPtrArray PeroneusTertiusMuscles = ObjSearch(MusPrefix+".*.PeroneusTertius*", "AnyMuscle");
   AnyFloat  PeroneusTertiusRmin = repmat(NumElemOf(PeroneusTertiusMuscles), ..RMin);
   AnyFloat  PeroneusTertiusRmax = repmat(NumElemOf(PeroneusTertiusMuscles), ..RMax);
   
   // Two-joint muscles
-  AnyObjectPtrArray GastrocnemiusMuscles = ObjSearch(MusPrefix+".Gastrocnemius*", "AnyMuscle");
+  AnyObjectPtrArray GastrocnemiusMuscles = ObjSearch(MusPrefix+".*.Gastrocnemius*", "AnyMuscle");
   AnyFloat  GastrocnemiusRmin = repmat(NumElemOf(GastrocnemiusMuscles), ..RMin);
   AnyFloat  GastrocnemiusRmax = repmat(NumElemOf(GastrocnemiusMuscles), ..RMax);
   
-  AnyObjectPtrArray PlantarisMuscles = ObjSearch(MusPrefix+".Plantaris*", "AnyMuscle");
+  AnyObjectPtrArray PlantarisMuscles = ObjSearch(MusPrefix+".*.Plantaris*", "AnyMuscle");
   AnyFloat  PlantarisRmin = repmat(NumElemOf(PlantarisMuscles), ..RMin);
   AnyFloat  PlantarisRmax = repmat(NumElemOf(PlantarisMuscles), ..RMax);
 

--- a/Body/AAUHuman/LegTLEM/Calibration/HipMuscleCal.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/HipMuscleCal.any
@@ -126,55 +126,55 @@ AnyFolder LegCalHip =
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray GluteusMaximusMuscles = ObjSearch(MusPrefix+".GluteusMaximus*", "AnyMuscle");
+  AnyObjectPtrArray GluteusMaximusMuscles = ObjSearch(MusPrefix+".*.GluteusMaximus*", "AnyMuscle");
   AnyFloat  GluteusMaximusRmin = repmat(NumElemOf(GluteusMaximusMuscles), ..RMin);
   AnyFloat  GluteusMaximusRmax = repmat(NumElemOf(GluteusMaximusMuscles), ..RMax);
   
-  AnyObjectPtrArray GluteusMediusMuscles = ObjSearch(MusPrefix+".GluteusMedius*", "AnyMuscle");
+  AnyObjectPtrArray GluteusMediusMuscles = ObjSearch(MusPrefix+".*.GluteusMedius*", "AnyMuscle");
   AnyFloat  GluteusMediusRmin = repmat(NumElemOf(GluteusMediusMuscles), ..RMin);
   AnyFloat  GluteusMediusRmax = repmat(NumElemOf(GluteusMediusMuscles), ..RMax);
 
-  AnyObjectPtrArray GluteusMinimusMuscles = ObjSearch(MusPrefix+".GluteusMinimus*", "AnyMuscle");
+  AnyObjectPtrArray GluteusMinimusMuscles = ObjSearch(MusPrefix+".*.GluteusMinimus*", "AnyMuscle");
   AnyFloat  GluteusMinimusRmin = repmat(NumElemOf(GluteusMinimusMuscles), ..RMin);
   AnyFloat  GluteusMinimusRmax = repmat(NumElemOf(GluteusMinimusMuscles), ..RMax);
   
-  AnyObjectPtrArray PiriformisMuscles = ObjSearch(MusPrefix+".Piriformis*", "AnyMuscle");
+  AnyObjectPtrArray PiriformisMuscles = ObjSearch(MusPrefix+".*.Piriformis*", "AnyMuscle");
   AnyFloat  PiriformisRmin = repmat(NumElemOf(PiriformisMuscles), ..RMin);
   AnyFloat  PiriformisRmax = repmat(NumElemOf(PiriformisMuscles), ..RMax);
   
-  AnyObjectPtrArray GemellusMuscles = ObjSearch(MusPrefix+".Gemellus*", "AnyMuscle");
+  AnyObjectPtrArray GemellusMuscles = ObjSearch(MusPrefix+".*.Gemellus*", "AnyMuscle");
   AnyFloat  GemellusRmin = repmat(NumElemOf(GemellusMuscles), ..RMin);
   AnyFloat  GemellusRmax = repmat(NumElemOf(GemellusMuscles), ..RMax);
   
-  AnyObjectPtrArray ObturatorInternusMuscles = ObjSearch(MusPrefix+".ObturatorInternus*", "AnyMuscle");
+  AnyObjectPtrArray ObturatorInternusMuscles = ObjSearch(MusPrefix+".*.ObturatorInternus*", "AnyMuscle");
   AnyFloat  ObturatorInternusRmin = repmat(NumElemOf(ObturatorInternusMuscles), ..RMin);
   AnyFloat  ObturatorInternusRmax = repmat(NumElemOf(ObturatorInternusMuscles), ..RMax);
   
-  AnyObjectPtrArray ObturatorExternusMuscles = ObjSearch(MusPrefix+".ObturatorExternus*", "AnyMuscle");
+  AnyObjectPtrArray ObturatorExternusMuscles = ObjSearch(MusPrefix+".*.ObturatorExternus*", "AnyMuscle");
   AnyFloat  ObturatorExternusRmin = repmat(NumElemOf(ObturatorExternusMuscles), ..RMin);
   AnyFloat  ObturatorExternusRmax = repmat(NumElemOf(ObturatorExternusMuscles), ..RMax);
   
-  AnyObjectPtrArray QuadratusFemorisMuscles = ObjSearch(MusPrefix+".QuadratusFemoris*", "AnyMuscle");
+  AnyObjectPtrArray QuadratusFemorisMuscles = ObjSearch(MusPrefix+".*.QuadratusFemoris*", "AnyMuscle");
   AnyFloat  QuadratusFemorisRmin = repmat(NumElemOf(QuadratusFemorisMuscles), ..RMin);
   AnyFloat  QuadratusFemorisRmax = repmat(NumElemOf(QuadratusFemorisMuscles), ..RMax);
   
-  AnyObjectPtrArray AdductorMagnusMuscles = ObjSearch(MusPrefix+".AdductorMagnus*", "AnyMuscle");
+  AnyObjectPtrArray AdductorMagnusMuscles = ObjSearch(MusPrefix+".*.AdductorMagnus*", "AnyMuscle");
   AnyFloat  AdductorMagnusRmin = repmat(NumElemOf(AdductorMagnusMuscles), ..RMin);
   AnyFloat  AdductorMagnusRmax = repmat(NumElemOf(AdductorMagnusMuscles), ..RMax);
   
-  AnyObjectPtrArray AdductorLongusMuscles = ObjSearch(MusPrefix+".AdductorLongus*", "AnyMuscle");
+  AnyObjectPtrArray AdductorLongusMuscles = ObjSearch(MusPrefix+".*.AdductorLongus*", "AnyMuscle");
   AnyFloat  AdductorLongusRmin = repmat(NumElemOf(AdductorLongusMuscles), ..RMin);
   AnyFloat  AdductorLongusRmax = repmat(NumElemOf(AdductorLongusMuscles), ..RMax);
   
-  AnyObjectPtrArray AdductorBrevisMuscles = ObjSearch(MusPrefix+".AdductorBrevis*", "AnyMuscle");
+  AnyObjectPtrArray AdductorBrevisMuscles = ObjSearch(MusPrefix+".*.AdductorBrevis*", "AnyMuscle");
   AnyFloat  AdductorBrevisRmin = repmat(NumElemOf(AdductorBrevisMuscles), ..RMin);
   AnyFloat  AdductorBrevisRmax = repmat(NumElemOf(AdductorBrevisMuscles), ..RMax);
   
-  AnyObjectPtrArray PectineusMuscles = ObjSearch(MusPrefix+".Pectineus*", "AnyMuscle");
+  AnyObjectPtrArray PectineusMuscles = ObjSearch(MusPrefix+".*.Pectineus*", "AnyMuscle");
   AnyFloat  PectineusRmin = repmat(NumElemOf(PectineusMuscles), ..RMin);
   AnyFloat  PectineusRmax = repmat(NumElemOf(PectineusMuscles), ..RMax);
   
-  AnyObjectPtrArray IliacusMuscles = ObjSearch(MusPrefix+".Iliacus*", "AnyMuscle");
+  AnyObjectPtrArray IliacusMuscles = ObjSearch(MusPrefix+".*.Iliacus*", "AnyMuscle");
   AnyFloat  IliacusRmin = repmat(NumElemOf(IliacusMuscles), ..RMin);
   AnyFloat  IliacusRmax = repmat(NumElemOf(IliacusMuscles), ..RMax);
   
@@ -185,31 +185,31 @@ AnyFolder LegCalHip =
   
   // Two-joint muscles
   
-  AnyObjectPtrArray TensorFasciaeLataeMuscles = ObjSearch(MusPrefix+".TensorFasciaeLatae*", "AnyMuscle");
+  AnyObjectPtrArray TensorFasciaeLataeMuscles = ObjSearch(MusPrefix+".*.TensorFasciaeLatae*", "AnyMuscle");
   AnyFloat  TensorFasciaeLataeRmin = repmat(NumElemOf(TensorFasciaeLataeMuscles), ..RMin);
   AnyFloat  TensorFasciaeLataeRmax = repmat(NumElemOf(TensorFasciaeLataeMuscles), ..RMax);
   
-  AnyObjectPtrArray RectusFemorisMuscles = ObjSearch(MusPrefix+".RectusFemoris*", "AnyMuscle");
+  AnyObjectPtrArray RectusFemorisMuscles = ObjSearch(MusPrefix+".*.RectusFemoris*", "AnyMuscle");
   AnyFloat  RectusFemorisRmin = repmat(NumElemOf(RectusFemorisMuscles), ..RMin);
   AnyFloat  RectusFemorisRmax = repmat(NumElemOf(RectusFemorisMuscles), ..RMax);
   
-  AnyObjectPtrArray SartoriusMuscles = ObjSearch(MusPrefix+".Sartorius*", "AnyMuscle");
+  AnyObjectPtrArray SartoriusMuscles = ObjSearch(MusPrefix+".*.Sartorius*", "AnyMuscle");
   AnyFloat  SartoriusRmin = repmat(NumElemOf(SartoriusMuscles), ..RMin);
   AnyFloat  SartoriusRmax = repmat(NumElemOf(SartoriusMuscles), ..RMax);
   
-  AnyObjectPtrArray GracilisMuscles = ObjSearch(MusPrefix+".Gracilis*", "AnyMuscle");
+  AnyObjectPtrArray GracilisMuscles = ObjSearch(MusPrefix+".*.Gracilis*", "AnyMuscle");
   AnyFloat  GracilisRmin = repmat(NumElemOf(GracilisMuscles), ..RMin);
   AnyFloat  GracilisRmax = repmat(NumElemOf(GracilisMuscles), ..RMax);
   
-  AnyObjectPtrArray BicepsFemorisMuscles = ObjSearch(MusPrefix+".BicepsFemoris*", "AnyMuscle");
+  AnyObjectPtrArray BicepsFemorisMuscles = ObjSearch(MusPrefix+".*.BicepsFemoris*", "AnyMuscle");
   AnyFloat  BicepsFemorisRmin = repmat(NumElemOf(BicepsFemorisMuscles), ..RMin);
   AnyFloat  BicepsFemorisRmax = repmat(NumElemOf(BicepsFemorisMuscles), ..RMax);
   
-  AnyObjectPtrArray SemimembranosusMuscles = ObjSearch(MusPrefix+".Semimembranosus*", "AnyMuscle");
+  AnyObjectPtrArray SemimembranosusMuscles = ObjSearch(MusPrefix+".*.Semimembranosus*", "AnyMuscle");
   AnyFloat  SemimembranosusRmin = repmat(NumElemOf(SemimembranosusMuscles), ..RMin);
   AnyFloat  SemimembranosusRmax = repmat(NumElemOf(SemimembranosusMuscles), ..RMax);
   
-  AnyObjectPtrArray SemitendinosusMuscles = ObjSearch(MusPrefix+".Semitendinosus*", "AnyMuscle");
+  AnyObjectPtrArray SemitendinosusMuscles = ObjSearch(MusPrefix+".*.Semitendinosus*", "AnyMuscle");
   AnyFloat  SemitendinosusRmin = repmat(NumElemOf(SemitendinosusMuscles), ..RMin);
   AnyFloat  SemitendinosusRmax = repmat(NumElemOf(SemitendinosusMuscles), ..RMax);  
 };

--- a/Body/AAUHuman/LegTLEM/Calibration/KneeMuscleCal.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/KneeMuscleCal.any
@@ -107,19 +107,19 @@ AnyFolder LegCalKnee =
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray VastusMedialisMuscles = ObjSearch(MusPrefix+".VastusMedialis*", "AnyMuscle");
+  AnyObjectPtrArray VastusMedialisMuscles = ObjSearch(MusPrefix+".*.VastusMedialis*", "AnyMuscle");
   AnyFloat  VastusMedialisRmin = repmat(NumElemOf(VastusMedialisMuscles), ..RMin);
   AnyFloat  VastusMedialisRmax = repmat(NumElemOf(VastusMedialisMuscles), ..RMax);
   
-  AnyObjectPtrArray VastusLateralisMuscles = ObjSearch(MusPrefix+".VastusLateralis*", "AnyMuscle");
+  AnyObjectPtrArray VastusLateralisMuscles = ObjSearch(MusPrefix+".*.VastusLateralis*", "AnyMuscle");
   AnyFloat  VastusLateralisRmin = repmat(NumElemOf(VastusLateralisMuscles), ..RMin);
   AnyFloat  VastusLateralisRmax = repmat(NumElemOf(VastusLateralisMuscles), ..RMax);
   
-  AnyObjectPtrArray VastusIntermediusMuscles = ObjSearch(MusPrefix+".VastusIntermedius*", "AnyMuscle");
+  AnyObjectPtrArray VastusIntermediusMuscles = ObjSearch(MusPrefix+".*.VastusIntermedius*", "AnyMuscle");
   AnyFloat  VastusIntermediusRmin = repmat(NumElemOf(VastusIntermediusMuscles), ..RMin);
   AnyFloat  VastusIntermediusRmax = repmat(NumElemOf(VastusIntermediusMuscles), ..RMax);
   
-  AnyObjectPtrArray PopliteusMuscles = ObjSearch(MusPrefix+".Popliteus*", "AnyMuscle");
+  AnyObjectPtrArray PopliteusMuscles = ObjSearch(MusPrefix+".*.Popliteus*", "AnyMuscle");
   AnyFloat  PopliteusRmin = repmat(NumElemOf(PopliteusMuscles), ..RMin);
   AnyFloat  PopliteusRmax = repmat(NumElemOf(PopliteusMuscles), ..RMax);
   

--- a/Body/AAUHuman/LegTLEM/Calibration/LegCal2.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/LegCal2.any
@@ -77,11 +77,11 @@ AnyKinEq PelvisFix = {
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray TibialisPosteriorMuscles = ObjSearch(MusPrefix+".TibialisPosterior*", "AnyMuscle");
-  AnyObjectPtrArray GastrocnemiusMuscles = ObjSearch(MusPrefix+".Gastrocnemius*", "AnyMuscle");
-  AnyObjectPtrArray FlexorMuscles = ObjSearch(MusPrefix+".Flexor*", "AnyMuscle");
-  AnyObjectPtrArray PlantarisMuscles = ObjSearch(MusPrefix+".Plantaris*", "AnyMuscle");
-  AnyObjectPtrArray GluteusMaximusMuscles = ObjSearch(MusPrefix+".GluteusMaximus*", "AnyMuscle");
+  AnyObjectPtrArray TibialisPosteriorMuscles = ObjSearch(MusPrefix+".*.TibialisPosterior*", "AnyMuscle");
+  AnyObjectPtrArray GastrocnemiusMuscles = ObjSearch(MusPrefix+".*.Gastrocnemius*", "AnyMuscle");
+  AnyObjectPtrArray FlexorMuscles = ObjSearch(MusPrefix+".*.Flexor*", "AnyMuscle");
+  AnyObjectPtrArray PlantarisMuscles = ObjSearch(MusPrefix+".*.Plantaris*", "AnyMuscle");
+  AnyObjectPtrArray GluteusMaximusMuscles = ObjSearch(MusPrefix+".*.GluteusMaximus*", "AnyMuscle");
 };
 
 // The study: Operations to be performed on the model

--- a/Body/AAUHuman/LegTLEM/Calibration/LegCal3.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/LegCal3.any
@@ -76,10 +76,10 @@ AnyFolder LegCal3={
 
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray TibialisAnteriorMuscles = ObjSearch(MusPrefix+".TibialisAnterior*", "AnyMuscle");
-  AnyObjectPtrArray PeroneusTertiusMuscles = ObjSearch(MusPrefix+".PeroneusTertius*", "AnyMuscle");
-  AnyObjectPtrArray ExtensorDigitorumLongusMuscles = ObjSearch(MusPrefix+".ExtensorDigitorumLongus*", "AnyMuscle");
-  AnyObjectPtrArray ExtensorHallucisLongusMuscles = ObjSearch(MusPrefix+".ExtensorHallucisLongus*", "AnyMuscle");
+  AnyObjectPtrArray TibialisAnteriorMuscles = ObjSearch(MusPrefix+".*.TibialisAnterior*", "AnyMuscle");
+  AnyObjectPtrArray PeroneusTertiusMuscles = ObjSearch(MusPrefix+".*.PeroneusTertius*", "AnyMuscle");
+  AnyObjectPtrArray ExtensorDigitorumLongusMuscles = ObjSearch(MusPrefix+".*.ExtensorDigitorumLongus*", "AnyMuscle");
+  AnyObjectPtrArray ExtensorHallucisLongusMuscles = ObjSearch(MusPrefix+".*.ExtensorHallucisLongus*", "AnyMuscle");
 };
 
 // The study: Operations to be performed on the model

--- a/Body/AAUHuman/LegTLEM/Calibration/LegCal5.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/LegCal5.any
@@ -76,11 +76,11 @@ AnyFolder LegCal5={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray VastusLateralisMuscles = ObjSearch(MusPrefix+".VastusLateralis*", "AnyMuscle");  
-  AnyObjectPtrArray VastusMedialisMuscles = ObjSearch(MusPrefix+".VastusMedialis*", "AnyMuscle");
-  AnyObjectPtrArray VastusIntermediusMuscles = ObjSearch(MusPrefix+".VastusIntermedius*", "AnyMuscle");
-  AnyObjectPtrArray RectusFemoris1Muscles = ObjSearch(MusPrefix+".RectusFemoris1*", "AnyMuscle");
-  AnyObjectPtrArray PeroneusLongus = ObjSearch(MusPrefix+".PeroneusLongus*", "AnyMuscle");
+  AnyObjectPtrArray VastusLateralisMuscles = ObjSearch(MusPrefix+".*.VastusLateralis*", "AnyMuscle");  
+  AnyObjectPtrArray VastusMedialisMuscles = ObjSearch(MusPrefix+".*.VastusMedialis*", "AnyMuscle");
+  AnyObjectPtrArray VastusIntermediusMuscles = ObjSearch(MusPrefix+".*.VastusIntermedius*", "AnyMuscle");
+  AnyObjectPtrArray RectusFemoris1Muscles = ObjSearch(MusPrefix+".*.RectusFemoris1*", "AnyMuscle");
+  AnyObjectPtrArray PeroneusLongus = ObjSearch(MusPrefix+".*.PeroneusLongus*", "AnyMuscle");
 };
 
 // The study: Operations to be performed on the model

--- a/Body/AAUHuman/LegTLEM/Calibration/LegCal6.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/LegCal6.any
@@ -76,11 +76,11 @@ AnyFolder LegCal6={
 
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray GluteusMinimusMuscles = ObjSearch(MusPrefix+".GluteusMinimus*", "AnyMuscle");  
-  AnyObjectPtrArray GluteusMediusMuscles = ObjSearch(MusPrefix+".GluteusMedius*", "AnyMuscle");
-  AnyObjectPtrArray SoleusMuscles = ObjSearch(MusPrefix+".Soleus*", "AnyMuscle");
-  AnyObjectPtrArray GemellusInferiorMuscles = ObjSearch(MusPrefix+".Gemellus*", "AnyMuscle");
-  AnyObjectPtrArray TensorFasciaeLataeMuscles = ObjSearch(MusPrefix+".TensorFasciaeLatae*", "AnyMuscle");
+  AnyObjectPtrArray GluteusMinimusMuscles = ObjSearch(MusPrefix+".*.GluteusMinimus*", "AnyMuscle");  
+  AnyObjectPtrArray GluteusMediusMuscles = ObjSearch(MusPrefix+".*.GluteusMedius*", "AnyMuscle");
+  AnyObjectPtrArray SoleusMuscles = ObjSearch(MusPrefix+".*.Soleus*", "AnyMuscle");
+  AnyObjectPtrArray GemellusInferiorMuscles = ObjSearch(MusPrefix+".*.Gemellus*", "AnyMuscle");
+  AnyObjectPtrArray TensorFasciaeLataeMuscles = ObjSearch(MusPrefix+".*.TensorFasciaeLatae*", "AnyMuscle");
 };
 
 // The study: Operations to be performed on the model

--- a/Body/AAUHuman/LegTLEM/Calibration/LegCal7.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/LegCal7.any
@@ -77,12 +77,12 @@ AnyFolder LegCal7 ={
 
 AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
   
-  AnyObjectPtrArray SemiMuscles = ObjSearch(MusPrefix+".Semi*", "AnyMuscle");  
-  AnyObjectPtrArray AdductorLongusMuscles = ObjSearch(MusPrefix+".AdductorLongus*", "AnyMuscle");
-  AnyObjectPtrArray AdductorMagnusMuscles = ObjSearch(MusPrefix+".AdductorMagnus*", "AnyMuscle");
-  AnyObjectPtrArray AdductorBrevisMuscles = ObjSearch(MusPrefix+".AdductorBrevis*", "AnyMuscle");
-  AnyObjectPtrArray GracilisMuscles = ObjSearch(MusPrefix+".Gracilis*", "AnyMuscle");
-  AnyObjectPtrArray PectineusMuscles = ObjSearch(MusPrefix+".Pectineus*", "AnyMuscle");
+  AnyObjectPtrArray SemiMuscles = ObjSearch(MusPrefix+".*.Semi*", "AnyMuscle");  
+  AnyObjectPtrArray AdductorLongusMuscles = ObjSearch(MusPrefix+".*.AdductorLongus*", "AnyMuscle");
+  AnyObjectPtrArray AdductorMagnusMuscles = ObjSearch(MusPrefix+".*.AdductorMagnus*", "AnyMuscle");
+  AnyObjectPtrArray AdductorBrevisMuscles = ObjSearch(MusPrefix+".*.AdductorBrevis*", "AnyMuscle");
+  AnyObjectPtrArray GracilisMuscles = ObjSearch(MusPrefix+".*.Gracilis*", "AnyMuscle");
+  AnyObjectPtrArray PectineusMuscles = ObjSearch(MusPrefix+".*.Pectineus*", "AnyMuscle");
   
 };
 

--- a/Body/AAUHuman/LegTLEM/Calibration/LegCal8.any
+++ b/Body/AAUHuman/LegTLEM/Calibration/LegCal8.any
@@ -78,10 +78,10 @@ AnyFolder LegCal8={
   
   AnyString MusPrefix = CompleteNameOf(&.SideHumanFolderRef.Leg.Mus);
 
-  AnyObjectPtrArray ObturatorExternusMuscles = ObjSearch(MusPrefix+".ObturatorExternus*", "AnyMuscle");  
-  AnyObjectPtrArray ObturatorInternusMuscles = ObjSearch(MusPrefix+".ObturatorInternus*", "AnyMuscle");
-  AnyObjectPtrArray GemellusMuscles = ObjSearch(MusPrefix+".Gemellus*", "AnyMuscle");
-  AnyObjectPtrArray QuadratusFemorisMuscles = ObjSearch(MusPrefix+".QuadratusFemoris*", "AnyMuscle");
+  AnyObjectPtrArray ObturatorExternusMuscles = ObjSearch(MusPrefix+".*.ObturatorExternus*", "AnyMuscle");  
+  AnyObjectPtrArray ObturatorInternusMuscles = ObjSearch(MusPrefix+".*.ObturatorInternus*", "AnyMuscle");
+  AnyObjectPtrArray GemellusMuscles = ObjSearch(MusPrefix+".*.Gemellus*", "AnyMuscle");
+  AnyObjectPtrArray QuadratusFemorisMuscles = ObjSearch(MusPrefix+".*.QuadratusFemoris*", "AnyMuscle");
 };
 
 // The study: Operations to be performed on the model

--- a/Body/AAUHuman/Trunk/Calibration/MuscleCalibrationSequence.any
+++ b/Body/AAUHuman/Trunk/Calibration/MuscleCalibrationSequence.any
@@ -13,13 +13,13 @@ AnyFolder ThoraxMuscleCalibration = {
     
     AnyFolder& Joints =  ...BodyModel.Trunk.Joints;
     AnyFolder& Muscles =  ...BodyModel.Trunk.Muscles;
+    #if BM_LEG_MODEL & BM_LEG_RIGHT
+    AnyFolder& RightThigh = ...BodyModel.Right.Leg.Seg.Thigh;
+    AnyFolder& RightHipJoint =  ...BodyModel.Right.Leg.Jnt.Hip;
+    #endif
     #if BM_LEG_MODEL & BM_LEG_LEFT
     AnyFolder& LeftThigh = ...BodyModel.Left.Leg.Seg.Thigh;
     AnyFolder& LeftHipJoint =  ...BodyModel.Left.Leg.Jnt.Hip;
-    #endif
-    #if BM_LEG_MODEL & BM_LEG_LEFT
-    AnyFolder& RightThigh = ...BodyModel.Right.Leg.Seg.Thigh;
-    AnyFolder& RightHipJoint =  ...BodyModel.Right.Leg.Jnt.Hip;
     #endif
     
     

--- a/Body/AAUHuman/Trunk/Calibration/MuscleCalibrationSequence2Par.any
+++ b/Body/AAUHuman/Trunk/Calibration/MuscleCalibrationSequence2Par.any
@@ -23,7 +23,7 @@ AnyFolder ThoraxMuscleCalibration={
     AnyFolder& LeftThigh = ...BodyModel.Left.Leg.Seg.Thigh;
     AnyFolder& LeftHipJoint =  ...BodyModel.Left.Leg.Jnt.Hip;
     #endif
-    #if BM_LEG_MODEL & BM_LEG_LEFT
+    #if BM_LEG_MODEL & BM_LEG_RIGHT
     AnyFolder& RightThigh = ...BodyModel.Right.Leg.Seg.Thigh;
     AnyFolder& RightHipJoint =  ...BodyModel.Right.Leg.Jnt.Hip;
     #endif
@@ -102,8 +102,6 @@ AnyFolder ThoraxMuscleCalibration={
     };
     
     #if BM_LEG_RIGHT != OFF
-      AnyFolder &HJR = Main.HumanModel.BodyModel.Right.Leg.Jnt.Hip;
-      AnyFolder &RightThigh =  ...BodyModel.Right.Leg.Seg.Thigh;
       AnyKinEq RightHipDriver = {
         AnyKinMeasure& PelvisThoraxExtension = ....BodyModel.Interface.Right.HipAbduction;
         AnyKinMeasure& PelvisThoraxLateralBending = ....BodyModel.Interface.Right.HipFlexion;
@@ -112,8 +110,6 @@ AnyFolder ThoraxMuscleCalibration={
     #endif  
 
     #if BM_LEG_LEFT != OFF
-      AnyFolder &HJL = Main.HumanModel.BodyModel.Left.Leg.Jnt.Hip;
-      AnyFolder &LeftThigh =  ...BodyModel.Left.Leg.Seg.Thigh;
       AnyKinEq LeftHipDriver = {
         AnyKinMeasure& PelvisThoraxExtension = ....BodyModel.Interface.Left.HipAbduction;
         AnyKinMeasure& PelvisThoraxLateralBending = ....BodyModel.Interface.Left.HipFlexion;

--- a/Body/AAUHuman/Trunk/Calibration/MuscleCalibrationSequence2Par.any
+++ b/Body/AAUHuman/Trunk/Calibration/MuscleCalibrationSequence2Par.any
@@ -19,13 +19,13 @@ AnyFolder ThoraxMuscleCalibration={
     
     AnyFolder& Joints =  ...BodyModel.Trunk.Joints;
     AnyFolder& Muscles =  ...BodyModel.Trunk.Muscles;
-    #if BM_LEG_MODEL & BM_LEG_LEFT
-    AnyFolder& LeftThigh = ...BodyModel.Left.Leg.Seg.Thigh;
-    AnyFolder& LeftHipJoint =  ...BodyModel.Left.Leg.Jnt.Hip;
-    #endif
     #if BM_LEG_MODEL & BM_LEG_RIGHT
     AnyFolder& RightThigh = ...BodyModel.Right.Leg.Seg.Thigh;
     AnyFolder& RightHipJoint =  ...BodyModel.Right.Leg.Jnt.Hip;
+    #endif
+    #if BM_LEG_MODEL & BM_LEG_LEFT
+    AnyFolder& LeftThigh = ...BodyModel.Left.Leg.Seg.Thigh;
+    AnyFolder& LeftHipJoint =  ...BodyModel.Left.Leg.Jnt.Hip;
     #endif
         
      AnyFixedRefFrame ground = {
@@ -103,17 +103,17 @@ AnyFolder ThoraxMuscleCalibration={
     
     #if BM_LEG_RIGHT != OFF
       AnyKinEq RightHipDriver = {
-        AnyKinMeasure& PelvisThoraxExtension = ....BodyModel.Interface.Right.HipAbduction;
-        AnyKinMeasure& PelvisThoraxLateralBending = ....BodyModel.Interface.Right.HipFlexion;
-        AnyKinMeasure& PelvisThoraxRotation = ....BodyModel.Interface.Right.HipExternalRotation;    
+        AnyKinMeasure& HipAbduction = ....BodyModel.Interface.Right.HipAbduction;
+        AnyKinMeasure& HipFlexion = ....BodyModel.Interface.Right.HipFlexion;
+        AnyKinMeasure& HipExternalRotation = ....BodyModel.Interface.Right.HipExternalRotation;    
       };    
     #endif  
 
     #if BM_LEG_LEFT != OFF
       AnyKinEq LeftHipDriver = {
-        AnyKinMeasure& PelvisThoraxExtension = ....BodyModel.Interface.Left.HipAbduction;
-        AnyKinMeasure& PelvisThoraxLateralBending = ....BodyModel.Interface.Left.HipFlexion;
-        AnyKinMeasure& PelvisThoraxRotation = ....BodyModel.Interface.Left.HipExternalRotation;    
+        AnyKinMeasure& HipAbduction = ....BodyModel.Interface.Left.HipAbduction;
+        AnyKinMeasure& HipFlexion = ....BodyModel.Interface.Left.HipFlexion;
+        AnyKinMeasure& HipExternalRotation = ....BodyModel.Interface.Left.HipExternalRotation;    
       };    
     #endif  
   };


### PR DESCRIPTION
This PR fixes the muscle lists used in the calibration studies for arms and legs. Lists for both 1 PAR and 2 PAR type calibration have been updated.
This PR also fixes a small bug in 2 par calibration for trunk muscles. Leg Left was checked twice in an #if check instead of leg right. Duplicate references for hip joint and thigh seg are deleted.