### PR TITLE
fix: Add include guard to RotationPenetrationCombiDriver_template.any

### DIFF
--- a/Tools/ModelUtilities/KinematicLimits/RotationPenetrationCombiDriver_template.any
+++ b/Tools/ModelUtilities/KinematicLimits/RotationPenetrationCombiDriver_template.any
@@ -76,6 +76,9 @@ The class supports the following settings:
 |------------------------------|--------------|---------------------------------|-------------------------------------------------------------------------------------|
 
 */
+#ifndef ROTATIONPENETRATIONCOMBIDRIVER_TEMPLATE_ANY
+#define ROTATIONPENETRATIONCOMBIDRIVER_TEMPLATE_ANY
+
 
 #class_template RotationPenetrationCombiDriver (
   PLANE_BASE_FRAME = Main.EnvironmentModel.GlobalRef,
@@ -283,3 +286,6 @@ The class supports the following settings:
     }; // Condition Check
 
   };
+
+
+#endif // ROTATIONPENETRATIONCOMBIDRIVER_TEMPLATE_ANY


### PR DESCRIPTION
This pull request includes changes to the `RotationPenetrationCombiDriver_template.any` file to add include guards. This ensures that the file is only included once during compilation, preventing potential redefinition errors.