### PR TITLE
feat: Add new AutoPelvisPos2 class template with a new easier interface

### DIFF
--- a/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S1/S1_FlywheelSquat/TrialSpecificData.any
+++ b/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S1/S1_FlywheelSquat/TrialSpecificData.any
@@ -36,9 +36,11 @@ Main.ModelSetup.TrialSpecificData =
   //#define MOCAP_OUTPUT_FILENAME_PREFIX ""
   
   
-   // This class_template calculates the load time position and orientation of 
-   // the pelvis based on markers.
-   AutoPelvisPos AutoPos(RASIS=RASI, LASIS=LASI, BACK=RPSI) = {};
+  // This class_template calculates the load time position and orientation of 
+  // the pelvis based on markers.
+  SetInitialPelvisPosture AutoPos() = {
+    PelvisMarkers = {"RASI", "LASI", "RPSI", "LPSI"};
+  };
 
   /// The following settings define the initial posture of the
   /// model (e.g. at load time)

--- a/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S1/S1_StandingRef/TrialSpecificData.any
+++ b/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S1/S1_StandingRef/TrialSpecificData.any
@@ -30,10 +30,11 @@ Main.ModelSetup.TrialSpecificData =
   //#define MOCAP_OUTPUT_FILENAME_PREFIX ""
   
   
-   // This class_template calculates the load time position and orientation of 
-   // the pelvis based on markers.
-   AutoPelvisPos AutoPos(RASIS=RASI, LASIS=LASI, BACK=RPSI) = {};
-
+  // This class_template calculates the load time position and orientation of 
+  // the pelvis based on markers.
+  SetInitialPelvisPosture AutoPos() = {
+    PelvisMarkers = {"RASI", "LASI", "RPSI", "LPSI"};
+  };
   /// The following settings define the initial posture of the
   /// model (e.g. at load time)
   Main.HumanModel.Mannequin.Posture = {

--- a/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S2/S2_FlywheelSquat/TrialSpecificData.any
+++ b/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S2/S2_FlywheelSquat/TrialSpecificData.any
@@ -36,9 +36,11 @@ Main.ModelSetup.TrialSpecificData =
   //#define MOCAP_OUTPUT_FILENAME_PREFIX ""
   
   
-   // This class_template calculates the load time position and orientation of 
-   // the pelvis based on markers.
-   AutoPelvisPos AutoPos(RASIS=RASI, LASIS=LASI, BACK=RPSI) = {};
+   / This class_template calculates the load time position and orientation of 
+  // the pelvis based on markers.
+  SetInitialPelvisPosture AutoPos() = {
+    PelvisMarkers = {"RASI", "LASI", "RPSI", "LPSI"};
+  };
 
   /// The following settings define the initial posture of the
   /// model (e.g. at load time)

--- a/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S2/S2_StandingRef/TrialSpecificData.any
+++ b/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/Subjects/S2/S2_StandingRef/TrialSpecificData.any
@@ -30,9 +30,11 @@ Main.ModelSetup.TrialSpecificData =
   //#define MOCAP_OUTPUT_FILENAME_PREFIX ""
   
   
-   // This class_template calculates the load time position and orientation of 
-   // the pelvis based on markers.
-   AutoPelvisPos AutoPos(RASIS=RASI, LASIS=LASI, BACK=RPSI) = {};
+  // This class_template calculates the load time position and orientation of 
+  // the pelvis based on markers.
+  SetInitialPelvisPosture AutoPos() = {
+    PelvisMarkers = {"RASI", "LASI", "RPSI", "LPSI"};
+  };
 
   /// The following settings define the initial posture of the
   /// model (e.g. at load time)

--- a/Body/AAUHuman/Trunk/SkullSeg.any
+++ b/Body/AAUHuman/Trunk/SkullSeg.any
@@ -39,7 +39,7 @@
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
     AnyRefNode& ScalingNode = AnatomicalFrame;
         
-    AnyRefNode C1C0JntNode = {sRel = .Scale(.Data.C1C0JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = {1,1,1}*0.003;RGB = {0, 1, 0};};};
+    AnyRefNode C1C0JntNode = {sRel = .Scale(.Data.C1C0JntNode_pos);};
     AnyRefNode NeckNode={sRel=.Scale(.Data.NeckNode_pos);};
     
     //Lumped Hyoid

--- a/Tools/AnyMocap/AutomaticInitialPositionOfBody.any
+++ b/Tools/AnyMocap/AutomaticInitialPositionOfBody.any
@@ -73,6 +73,87 @@ MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
     };
 };
 
+
+
+#class_template AutoPelvisPos2(
+C3D_OBJECT=Main.ModelSetup.C3DFileData,
+PELVIS_SEG = Main.HumanModel.BodyModel.Trunk.Segments.PelvisSeg,
+MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
+) {
+  #var AnyString PelvisMarkers;
+  #var AnyFloat Time = Main.Studies.MarkerTracking.tStart;
+  
+    AnyFunTransform3DLin2 RigidBodyTransform= {
+        AnyInt nMarkersIn = NumElemOf(.PelvisMarkers);
+        AnyInt NotEnoughMarkersSpecified = assert(gtfun(nMarkersIn,3), "AutoPelvisPos2 currently requires 4 markers");
+      
+        AnyString PelvisMarkersNames = repmat(nMarkersIn, {CompleteNameOf(&PELVIS_SEG)+"."})+ .PelvisMarkers + repmat(nMarkersIn, {"_Marker.sRel"});
+        AnyString C3dMarkerNames = repmat(nMarkersIn, {CompleteNameOf(&C3D_OBJECT)+".Points.Markers."})+ .PelvisMarkers + repmat(nMarkersIn, {".Pos"});
+
+        AnyInt nMarkersFound = SizesOf(Points0)[0];
+        AnyInt MissingMarkers = warn(eqfun(nMarkersFound, nMarkersIn), "Some markers were not found");
+        
+        // Calculate the index in the C3D data which corresponds to the tStart  variable.
+        AnyFloat tStartC3D = C3D_OBJECT.Header.FirstFrameNo/C3D_OBJECT.Header.VideoFrameRate;
+        AnyFloat tEndC3D = (C3D_OBJECT.Header.LastFrameNo+1)/C3D_OBJECT.Header.VideoFrameRate;
+        AnyInt nC3d = C3D_OBJECT.Header.LastFrameNo-C3D_OBJECT.Header.FirstFrameNo+1;
+        AnyFloat closest_idx = (nC3d)/(tEndC3D-tStartC3D)*(.Time -tStartC3D);
+        AnyInt start_idx = round( max({0.0,  min({closest_idx, nC3d } )}));
+  
+        
+        Points0 = Obj2Num(ObjSearch(PelvisMarkersNames));
+        Points1 = reshape(take(Obj2Num(ObjSearch(C3dMarkerNames)), {start_idx}, 1), {nMarkersFound,3});
+        AnyFloat Lin= take(TransformationMatrix, {3,7,11}); 
+        AnyFloat Rot= take(TransformationMatrix, {{0,1,2},{4,5,6},{8,9,10}});
+    };
+  
+      #var AnyVec3 PelvisPos = RigidBodyTransform.Lin + (PELVIS_SEG.AnatomicalFrameTrunk.sRel * PELVIS_SEG.Axes0');
+      #var AnyMat33 PelvisRotMat = RigidBodyTransform.Rot * PELVIS_SEG.AnatomicalFrameTrunk.ARel;
+                            
+    AnyFolder PelvisRotations = 
+    {
+       AnyVar yRot1 = asin(-.PelvisRotMat[2][0]);
+       AnyVar yRot2 = pi - yRot1;
+       
+       AnyVar zRot1 = atan2(.PelvisRotMat[1][0]/cos(yRot1), .PelvisRotMat[0][0]/cos(yRot1));
+       AnyVar zRot2 = atan2(.PelvisRotMat[1][0]/cos(yRot2), .PelvisRotMat[0][0]/cos(yRot2));
+       
+       AnyVar xRot1 = atan2(.PelvisRotMat[2][1]/cos(yRot1),.PelvisRotMat[2][2]/cos(yRot1));
+       AnyVar xRot2 = atan2(.PelvisRotMat[2][1]/cos(yRot2),.PelvisRotMat[2][2]/cos(yRot2));
+       AnyVar abs1 = abs(zRot1)+abs(yRot1)+abs(zRot1);
+       AnyVar abs2 = abs(zRot2)+abs(yRot2)+abs(zRot2);
+       
+       AnyVar zRot = iffun(gtfun(abs1, abs2), zRot2, zRot1);
+       AnyVar yRot = iffun(gtfun(abs1, abs2), yRot2, yRot1);
+       AnyVar xRot = iffun(gtfun(abs1, abs2), xRot2, xRot1);
+
+       // Check that the auto pos can reconstruct the rotation matrix.
+       AnyFloat err = abs(.PelvisRotMat-RotMat(zRot,z)*RotMat(yRot,y)*RotMat(xRot,x));
+       AnyInt AutoPosAssert = expect(ltfun(err,1e-5), "AutoPos failed to calculate the correct values");
+     };
+       
+    AnyFolder &InitPosRef= MANNEQUIN_FOLDER.Posture;    
+    InitPosRef= 
+    {
+      PelvisPosX = DesignVar(.PelvisPos[0]);
+      PelvisPosY = DesignVar(.PelvisPos[1]);
+      PelvisPosZ = DesignVar(.PelvisPos[2]);
+
+      PelvisRotX = DesignVar(.PelvisRotations.xRot*180/pi);
+      PelvisRotY = DesignVar(.PelvisRotations.yRot*180/pi);
+      PelvisRotZ = DesignVar(.PelvisRotations.zRot*180/pi);
+    };
+};
+
+
+
+
+
+
+
+
+
+
 #class_template AutomaticFullBodyInitialPosition (
 MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
 ) {

--- a/Tools/AnyMocap/AutomaticInitialPositionOfBody.any
+++ b/Tools/AnyMocap/AutomaticInitialPositionOfBody.any
@@ -127,7 +127,7 @@ MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
   
     AnyFunTransform3DLin2 CalculateRigidBodyTransform= {
         AnyInt nMarkersIn = NumElemOf(.PelvisMarkers);
-        AnyInt NotEnoughMarkersSpecified = assert(gtfun(nMarkersIn,3), "AutoPelvisPos2 currently requires 4 markers");
+        AnyInt NotEnoughMarkersSpecified = assert(gtfun(nMarkersIn,2), "AutoPelvisPos2 currently requires 3 markers");
       
         AnyString PelvisMarkersNames = repmat(nMarkersIn, {CompleteNameOf(&PELVIS_SEG)+"."})+ .PelvisMarkers + repmat(nMarkersIn, {"_Marker.sRel"});
         AnyString C3dMarkerNames = repmat(nMarkersIn, {CompleteNameOf(&C3D_OBJECT)+".Points.Markers."})+ .PelvisMarkers + repmat(nMarkersIn, {".Pos"});

--- a/Tools/AnyMocap/AutomaticInitialPositionOfBody.any
+++ b/Tools/AnyMocap/AutomaticInitialPositionOfBody.any
@@ -1,5 +1,16 @@
 #ifndef _ANYMOCAP_AUTOMATIC_INITIAL_POSITION_OF_BODY_ANY_
 #define _ANYMOCAP_AUTOMATIC_INITIAL_POSITION_OF_BODY_ANY_
+/*
+---
+group: MoCap
+topic: Markers
+descr: Set the initial position of body parts based on the position of the markers in the C3D file.
+---
+
+See below for more details
+
+*/
+
 
 #class_template AutoPelvisPos(
 RASIS=RASI,
@@ -74,16 +85,47 @@ MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
 };
 
 
-
-#class_template AutoPelvisPos2(
+// This templates is used to set the initial position of the pelvis based on the
+// markers in the C3D file.
+//
+// It sets the HumanModel.Mannequin.Posture.PelvisPosX, PelvisPosY, PelvisPosZ,
+// PelvisRotX, PelvisRotY, PelvisRotZ variables so initial position of the model is closer
+// the true position hence helping the kinematic solver.
+// :::{rubric} For example
+// :::
+//
+// :::{code-block} AnyScript
+// SetInitialPelvisPosture AutoPelvisPos = {
+  //     PelvisMarkers = {"RASI", "LASI", "RPSIS", "LPSIS"};
+// };
+// :::
+//
+#class_template SetInitialPelvisPosture(
 C3D_OBJECT=Main.ModelSetup.C3DFileData,
 PELVIS_SEG = Main.HumanModel.BodyModel.Trunk.Segments.PelvisSeg,
 MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
 ) {
+
+//Class template arguments:
+//---------------------------
+// SetInitialPelvisPosture#C3D_OBJECT
+//    (Optional) The C3D object where markers are found. Default is Main.ModelSetup.C3DFileData.
+// SetInitialPelvisPosture#PELVIS_SEG
+//    (Optional) The pelvis segment. Default is Main.HumanModel.BodyModel.Trunk.Segments.PelvisSeg.
+// SetInitialPelvisPosture#MANNEQUIN_FOLDER
+//    (Optional) The mannequin folder. Default is Main.HumanModel.Mannequin
+
+
+// SetInitialPelvisPosture
+/// The pelvis marker labels used when calulating the pelvis position.
+/// The labels must be in the C3D file, and a minimum of 4 markers are required.
   #var AnyString PelvisMarkers;
+  
+  // SetInitialPelvisPosture
+  /// The time at which the pelvis position is calculated.
   #var AnyFloat Time = Main.Studies.MarkerTracking.tStart;
   
-    AnyFunTransform3DLin2 RigidBodyTransform= {
+    AnyFunTransform3DLin2 CalculateRigidBodyTransform= {
         AnyInt nMarkersIn = NumElemOf(.PelvisMarkers);
         AnyInt NotEnoughMarkersSpecified = assert(gtfun(nMarkersIn,3), "AutoPelvisPos2 currently requires 4 markers");
       
@@ -107,10 +149,10 @@ MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
         AnyFloat Rot= take(TransformationMatrix, {{0,1,2},{4,5,6},{8,9,10}});
     };
   
-      #var AnyVec3 PelvisPos = RigidBodyTransform.Lin + (PELVIS_SEG.AnatomicalFrameTrunk.sRel * PELVIS_SEG.Axes0');
-      #var AnyMat33 PelvisRotMat = RigidBodyTransform.Rot * PELVIS_SEG.AnatomicalFrameTrunk.ARel;
+      #var AnyVec3 PelvisPos = CalculateRigidBodyTransform.Lin + (PELVIS_SEG.AnatomicalFrameTrunk.sRel * PELVIS_SEG.Axes0');
+      #var AnyMat33 PelvisRotMat = CalculateRigidBodyTransform.Rot * PELVIS_SEG.AnatomicalFrameTrunk.ARel;
                             
-    AnyFolder PelvisRotations = 
+    AnyFolder CalculateRotAxesAngles =
     {
        AnyVar yRot1 = asin(-.PelvisRotMat[2][0]);
        AnyVar yRot2 = pi - yRot1;
@@ -139,15 +181,11 @@ MANNEQUIN_FOLDER = Main.HumanModel.Mannequin
       PelvisPosY = DesignVar(.PelvisPos[1]);
       PelvisPosZ = DesignVar(.PelvisPos[2]);
 
-      PelvisRotX = DesignVar(.PelvisRotations.xRot*180/pi);
-      PelvisRotY = DesignVar(.PelvisRotations.yRot*180/pi);
-      PelvisRotZ = DesignVar(.PelvisRotations.zRot*180/pi);
+      PelvisRotX = DesignVar(.CalculateRotAxesAngles.xRot*180/pi);
+      PelvisRotY = DesignVar(.CalculateRotAxesAngles.yRot*180/pi);
+      PelvisRotZ = DesignVar(.CalculateRotAxesAngles.zRot*180/pi);
     };
 };
-
-
-
-
 
 
 


### PR DESCRIPTION
We only need to give a list of marker names on the Pelvis to the `AutoPelvisPos2` class template. 

Currently it needs a minimum of 4 markers to due the constraints of `AnyFunTransform3DLin2`. 
@mdabt Can this be change to 3? 

It can also accept that some of the markers are missing as long as there are enough. In that case it prints a warning. 

@toerholm Can you review?

```
   AutoPelvisPos2 AutoPos() = {
       PelvisMarkers = {"RASIS", "LASIS", "RPSIS", "LPSIS", "RILA", "LILA"};
   };
```

Todo: Add a test