### PR TITLE
fix(ForcePlate): Update force plate data calculations for transducer position and rotation

### DIFF
--- a/Tools/AnyMocap/ForcePlates/ForcePlateAutoDetection.any
+++ b/Tools/AnyMocap/ForcePlates/ForcePlateAutoDetection.any
@@ -568,7 +568,9 @@ See below for more details
    {
      Type = Bspline;
      T = ..Time;
-     Data = ((1+0*farr(0.0,1.0,..NoAnalogData))'*{..ForcePlate.ForcePlateSeg.r0}+ (..ForcePlate.ForcePlateSeg.Axes0*.GRF_start.Data)')';
+     AnyVec3 TransducerGlobalPos = ..ForcePlate.ForcePlateSeg.r0 + (..ForcePlate.ForcePlateSeg.Axes0*..ForcePlate.ForcePlateSeg.TransducerLocation.sRel')';
+     AnyMat33 TransducerGlobalRot = ..ForcePlate.ForcePlateSeg.Axes0*..ForcePlate.ForcePlateSeg.TransducerLocation.ARel;
+     Data = ((1+0*farr(0.0,1.0,..NoAnalogData))'*{TransducerGlobalPos}+ (TransducerGlobalRot*.GRF_start.Data)')';
    };
 
    AnyFunInterpol GRF_normalized =


### PR DESCRIPTION
Update force plate COP calculation to account for difference in plate and transducer coordinate systems.

The error did not affect the actual COP calculated by AnyBody, only the COP calculated manually which could be used by kinematic contraints etc.