### PR TITLE
fix: update search string for leg moments in selected outputs

### DIFF
--- a/Body/AAUHuman/LegTLEM/LegMoments.any
+++ b/Body/AAUHuman/LegTLEM/LegMoments.any
@@ -42,7 +42,7 @@ AnyForceMomentMeasure2 AnklePlantarFlexionNetMomentMuscle =
            ObjSearch("..Seg.Foot.*", "AnySeg"));
 
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle")
   );
@@ -64,7 +64,7 @@ AnyForceMomentMeasure2 SubTalarEversionNetMomentMuscle =
                   ObjSearch("..Seg.Foot.Talus", "AnySeg"));
 
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle")
   );
@@ -82,8 +82,8 @@ AnyForceMomentMeasure2 AchillesTendonSubtalarEversion = {
 
   #ifndef LEG_WITH_JOINT_MUSCLES
   IncludeForces = arrcat(
-    ObjSearch("..Mus.Soleus*", "AnyMuscle"),
-    ObjSearch("..Mus.Gastrocnemius*", "AnyMuscle")
+    ObjSearch("..Mus.*.Soleus*", "AnyMuscle"),
+    ObjSearch("..Mus.*.Gastrocnemius*", "AnyMuscle")
   );
   #endif
 
@@ -101,12 +101,12 @@ AnyForceMomentMeasure2 InversionMusclesSubtalarEversion = {
 
   #ifndef LEG_WITH_JOINT_MUSCLES
   IncludeForces = arrcat(
-    ObjSearch("..Mus.FlexorDigitorum*", "AnyMuscle"),
-    ObjSearch("..Mus.FlexorHallucis*", "AnyMuscle"),
-    ObjSearch("..Mus.TibialisPosterior*", "AnyMuscle"),
-    ObjSearch("..Mus.TibialisAnterior*", "AnyMuscle"),
-    ObjSearch("..Mus.ExtensorDigitorum*", "AnyMuscle"),
-    ObjSearch("..Mus.ExtensorHallucis*", "AnyMuscle")
+    ObjSearch("..Mus.*.FlexorDigitorum*", "AnyMuscle"),
+    ObjSearch("..Mus.*.FlexorHallucis*", "AnyMuscle"),
+    ObjSearch("..Mus.*.TibialisPosterior*", "AnyMuscle"),
+    ObjSearch("..Mus.*.TibialisAnterior*", "AnyMuscle"),
+    ObjSearch("..Mus.*.ExtensorDigitorum*", "AnyMuscle"),
+    ObjSearch("..Mus.*.ExtensorHallucis*", "AnyMuscle")
   );
   #endif
 
@@ -124,9 +124,9 @@ AnyForceMomentMeasure2 EversionMusclesSubtalarEversion = {
 
   #ifndef LEG_WITH_JOINT_MUSCLES
   IncludeForces = arrcat(
-    ObjSearch("..Mus.PeroneusTertius*", "AnyMuscle"),
-    ObjSearch("..Mus.PeroneusBrevis*", "AnyMuscle"),
-    ObjSearch("..Mus.PeroneusLongus*", "AnyMuscle")
+    ObjSearch("..Mus.*.PeroneusTertius*", "AnyMuscle"),
+    ObjSearch("..Mus.*.PeroneusBrevis*", "AnyMuscle"),
+    ObjSearch("..Mus.*.PeroneusLongus*", "AnyMuscle")
   );
   #endif
   AnyVec3 Mlocal=M*ref.Axes;
@@ -150,7 +150,7 @@ AnyForceMomentMeasure2 KneeNetMomentMuscle =
     &..Jnt.PatellaMovement.Reaction
   };
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle"),
     pArrJntReactions
@@ -185,7 +185,7 @@ AnyForceMomentMeasure2 HipNetMomentMuscle =
              ObjSearch("..Seg.Foot.*", "AnySeg"));
 
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle")
   );
@@ -215,7 +215,7 @@ AnyForceMomentMeasure2 AnklePlantarFlexionNetMoment =
     &..Jnt.SubTalar.Constraints.Reaction
   };
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle"),
     pArrJntReactions
@@ -239,7 +239,7 @@ AnyForceMomentMeasure2 SubTalarEversionNetMoment =
     &..Jnt.SubTalar.Constraints.Reaction
   };
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle"),
     pArrJntReactions
@@ -293,7 +293,7 @@ AnyForceMomentMeasure2 HipNetMoment =
     &..Jnt.PatellaMovement.Reaction
   };
   IncludeForces = arrcat(
-    ObjSearch("..Mus.*", "AnyMuscle"),
+    ObjSearch("..Mus.*.*", "AnyMuscle"),
     ObjSearch("..TrunkMuscles.PsoasMajor.*", "AnyMuscle"),
     ObjSearchRecursive("..JointMuscles", "*", "AnyMuscle"),
     pArrJntReactions


### PR DESCRIPTION
The search string for leg moments in selected output is updated to pick up leg muscles.

No changelog entry is made