### PR TITLE
feat: Add nodes for vertebra spinous process

### DIFF
--- a/Body/AAUHuman/Trunk/NodesForThoracicMuscles.any
+++ b/Body/AAUHuman/Trunk/NodesForThoracicMuscles.any
@@ -37,6 +37,7 @@ S = Sacral segment
   AnyRefNode O_serratus_posterior_inferior_L = {sRel = .Scale(.Data.Left.O_serratus_posterior_inferior_pos);};
   AnyRefNode O_serratus_posterior_inferior_L1R11ViaNode_R = {sRel = .Scale(.Data.Right.O_serratus_posterior_inferior_L1R11ViaNodepos);};
   AnyRefNode O_serratus_posterior_inferior_L1R11ViaNode_L = {sRel = .Scale(.Data.Left.O_serratus_posterior_inferior_L1R11ViaNodepos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.SupraSpinous_superior_points[0]);};
 };
 
 Segments.L2Seg = {
@@ -51,6 +52,7 @@ Segments.L2Seg = {
   AnyRefNode O_serratus_posterior_inferior_L = {sRel = .Scale(.Data.Left.O_serratus_posterior_inferior_pos);};
   AnyRefNode O_serratus_posterior_inferior_L2R12ViaNode_R = {sRel = .Scale(.Data.Right.O_serratus_posterior_inferior_L2R12ViaNodepos);};
   AnyRefNode O_serratus_posterior_inferior_L2R12ViaNode_L = {sRel = .Scale(.Data.Left.O_serratus_posterior_inferior_L2R12ViaNodepos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.SupraSpinous_superior_points[0]);};
 };
 
 Segments.L3Seg = {
@@ -60,6 +62,7 @@ Segments.L3Seg = {
   AnyRefNode MultifidusThoracisL3T11NodeLOrg = {sRel = .Scale(.Data.Left.MultifidusThoracisL3T11Node_pos);};
   AnyRefNode MultifidusThoracisL3T12NodeROrg = {sRel = .Scale(.Data.Right.MultifidusThoracisL3T12Node_pos);};
   AnyRefNode MultifidusThoracisL3T12NodeLOrg = {sRel = .Scale(.Data.Left.MultifidusThoracisL3T12Node_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.SupraSpinous_superior_points[0]);};
 };
 
 Segments.L4Seg = {
@@ -67,11 +70,13 @@ Segments.L4Seg = {
   AnyRefNode MultifidusThoracisL4T11NodeLOrg = {sRel = .Scale(.Data.Left.MultifidusThoracisL4T11Node_pos);};
   AnyRefNode MultifidusThoracisL4T12NodeROrg = {sRel = .Scale(.Data.Right.MultifidusThoracisL4T12Node_pos);};
   AnyRefNode MultifidusThoracisL4T12NodeLOrg = {sRel = .Scale(.Data.Left.MultifidusThoracisL4T12Node_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.SupraSpinous_superior_points[0]);};
 };
 
 Segments.L5Seg = {
   AnyRefNode MultifidusThoracisL5T12NodeROrg = {sRel = .Scale(.Data.Right.MultifidusThoracisL5T12Node_pos);};
   AnyRefNode MultifidusThoracisL5T12NodeLOrg = {sRel = .Scale(.Data.Left.MultifidusThoracisL5T12Node_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.SupraSpinous_superior_points[0]);};
 };
 
 Segments.T1Seg = {
@@ -107,6 +112,7 @@ Segments.T1Seg = {
   AnyRefNode O_serratus_posterior_superior_T1R = {sRel = .Scale(.Data.T1.O_serratus_posterior_superior_pos);};
   AnyRefNode O_serratus_posterior_superior_T1L = {sRel = .Scale(.Data.T1.O_serratus_posterior_superior_pos);};
   AnyRefNode C7Tip ={sRel= .Scale(.Data.T1.C7Tip_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T1.SupraSpinous_superior_points[0]);};
   //Longi Colli node
   Right = {
     AnyRefNode LongusColliT3C6Node = {sRel = .Scale(..Data.T1.Right.LongusColliT3C6Node_pos);};
@@ -214,6 +220,7 @@ Segments.T2Seg = {
   AnyRefNode MultifidusCervicisT2C6NodeL = {sRel = .Scale(.Data.Thorax.Left.MultifidusCervicisT2C6Node_pos);};
   AnyRefNode O_serratus_posterior_superior_T2R = {sRel = .Scale(.Data.T2.O_serratus_posterior_superior_pos);};
   AnyRefNode O_serratus_posterior_superior_T2L = {sRel = .Scale(.Data.T2.O_serratus_posterior_superior_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T2.SupraSpinous_superior_points[0]);};
   //Longi Colli node
   Right = {
     AnyRefNode LongusColliT3C6Node = {sRel = .Scale(..Data.T2.Right.LongusColliT3C6Node_pos);};
@@ -307,6 +314,8 @@ Segments.T3Seg = {
 //  AnyRefNode LongissimusThoracisR3L3NodeL  = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR3L3Node_pos);  };
   AnyRefNode O_serratus_posterior_superior_T3R = {sRel = .Scale(.Data.T3.O_serratus_posterior_superior_pos);};
   AnyRefNode O_serratus_posterior_superior_T3L = {sRel = .Scale(.Data.T3.O_serratus_posterior_superior_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T3.SupraSpinous_superior_points[0]);};
+
   Right = {
     //Longi Colli node
     AnyRefNode LongusColliT3C6Node = {sRel = .Scale(..Data.T3.Right.LongusColliT3C6Node_pos);};
@@ -408,6 +417,8 @@ Segments.T4Seg = {
 //  AnyRefNode LongissimusThoracisR4L4NodeL    = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR4L4Node_pos);};
   AnyRefNode MultifidusCervicisT4C7NodeR = {sRel = .Scale(.Data.Thorax.Right.MultifidusCervicisT4C7Node_pos);};
   AnyRefNode MultifidusCervicisT4C7NodeL = {sRel = .Scale(.Data.Thorax.Left.MultifidusCervicisT4C7Node_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T4.SupraSpinous_superior_points[0]);};
+
   Right = {
     //Semispinalis Capitis node
     AnyRefNode SemispinalisCapitisT4C0Node = {sRel = ..Scale(..Data.Thorax.Right.SemispinalisCapitisT4C0Node_pos);};
@@ -508,6 +519,8 @@ Segments.T5Seg = {
   AnyRefNode LevatorCostarumT5R6LOrg = {    sRel =  .Scale(.Data.T5.Left.LevatorCostarumT5R6_pos);};
   AnyRefNode LevatorCostarumT5R7ROrg = {    sRel =  .Scale(.Data.T5.Right.LevatorCostarumT5R7_pos);};
   AnyRefNode LevatorCostarumT5R7LOrg = {    sRel =  .Scale(.Data.T5.Left.LevatorCostarumT5R7_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T5.SupraSpinous_superior_points[0]);};
+
   Right = {
     //Semispinalis Capitis node
     AnyRefNode SemispinalisCapitisT5C0Node = {sRel = ..Scale(..Data.Thorax.Right.SemispinalisCapitisT5C0Node_pos);};
@@ -615,6 +628,8 @@ Segments.T6Seg = {
   AnyRefNode LevatorCostarumT6R7LOrg = {    sRel =  .Scale(.Data.T6.Left.LevatorCostarumT6R7_pos);};
   AnyRefNode LevatorCostarumT6R8ROrg = {    sRel = .Scale(.Data.T6.Right.LevatorCostarumT6R8_pos);};
   AnyRefNode LevatorCostarumT6R8LOrg = {    sRel = .Scale(.Data.T6.Left.LevatorCostarumT6R8_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T6.SupraSpinous_superior_points[0]);};
+
   Right = {
     //Semispinalis Capitis node
     AnyRefNode SemispinalisCapitisT6C0Node = {sRel = ..Scale(..Data.Thorax.Right.SemispinalisCapitisT6C0Node_pos);};
@@ -735,6 +750,7 @@ Segments.T7Seg = {
   AnyRefNode LongissimusThoracisR6S1Via1NodeL   = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR6S1Via1Node_pos);};
   AnyRefNode LongissimusThoracisR7S2NodeR       = { sRel =  .Scale(.Data.Thorax.Right.LongissimusThoracisR7S2Node_pos);};
   AnyRefNode LongissimusThoracisR7S2NodeL       = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR7S2Node_pos);};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T7.SupraSpinous_superior_points[0]);};
 
   Right = {
     //Rotatores
@@ -847,6 +863,7 @@ Segments.T8Seg = {
   AnyRefNode LongissimusThoracisR8S3NodeR       = { sRel =  .Scale(.Data.Thorax.Right.LongissimusThoracisR8S3Node_pos);};
   AnyRefNode LongissimusThoracisR8S3NodeL       = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR8S3Node_pos);};
   AnyRefNode MidPoint = { sRel = 0.5 * (.Scale(.Data.T8.T7T8JntNode_pos) + .Scale(.Data.T8.T8T9JntNode_pos));};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T8.SupraSpinous_superior_points[0]);};
 
   Right = {
     //Rotatores
@@ -963,6 +980,7 @@ Segments.T9Seg = {
   AnyRefNode LongissimusThoracisR9S4NodeR       = { sRel =  .Scale(.Data.Thorax.Right.LongissimusThoracisR9S4Node_pos);};
   AnyRefNode LongissimusThoracisR9S4NodeL       = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR9S4Node_pos);};
   AnyRefNode MidPoint = { sRel = 0.5 * (.Scale(.Data.T9.T8T9JntNode_pos) +.Scale(.Data.T9.T9T10JntNode_pos));};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T9.SupraSpinous_superior_points[0]);};
 
   Right = {
     //Rotatores
@@ -1081,6 +1099,8 @@ Segments.T10Seg = {
   AnyRefNode LongissimusThoracisR10S3NodeR  = { sRel =  .Scale(.Data.Thorax.Right.LongissimusThoracisR10S3Node_pos);};
   AnyRefNode LongissimusThoracisR10S3NodeL  = { sRel =  .Scale(.Data.Thorax.Left.LongissimusThoracisR10S3Node_pos);};
   AnyRefNode MidPoint = { sRel = 0.5 * (.Scale(.Data.T10.T9T10JntNode_pos) +.Scale(.Data.T10.T10T11JntNode_pos));};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T10.SupraSpinous_superior_points[0]);};
+
 
   Right = {
     //Rotatores
@@ -1202,6 +1222,7 @@ Segments.T11Seg = {
   AnyRefNode LevatorCostarumT11R12ROrg = {    sRel = .Scale(.Data.T11.Right.LevatorCostarumT11R12_pos);};
   AnyRefNode LevatorCostarumT11R12LOrg = {    sRel = .Scale(.Data.T11.Left.LevatorCostarumT11R12_pos);};
   AnyRefNode MidPoint = { sRel = 0.5 * (.Scale(.Data.T11.T10T11JntNode_pos) + .Scale(.Data.T11.T11T12JntNode_pos));};
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T11.SupraSpinous_superior_points[0]);};
 
   Right = {
     //Rotatores
@@ -1261,7 +1282,7 @@ Segments.T12Seg = {
   AnyRefNode LongissimusThoracisT6S1Via6NodeL      = {sRel = .Scale(.Data.Thorax.Left.LongissimusThoracisT6S1Via6Node_pos);};
   AnyRefNode LongissimusThoracisT7S2Via5NodeR      = {sRel = .Scale(.Data.Thorax.Right.LongissimusThoracisT7S2Via5Node_pos);};
   AnyRefNode LongissimusThoracisT7S2Via5NodeL      = {sRel = .Scale(.Data.Thorax.Left.LongissimusThoracisT7S2Via5Node_pos);};
-  
+
   AnyRefNode LongissimusThoracisT8S3Via4NodeR      = {sRel = .Scale(.Data.Thorax.Right.LongissimusThoracisT8S3Via4Node_pos);};
   AnyRefNode LongissimusThoracisT8S3Via4NodeL      = {sRel = .Scale(.Data.Thorax.Left.LongissimusThoracisT8S3Via4Node_pos);};
   AnyRefNode LongissimusThoracisT9S4Via3NodeR      = {sRel = .Scale(.Data.Thorax.Right.LongissimusThoracisT9S4Via3Node_pos);};
@@ -1293,7 +1314,7 @@ Segments.T12Seg = {
   AnyRefNode LongissimusThoracisR10S3Via2NodeL = {sRel = .Scale(.Data.R12.Left.LongissimusThoracisR10S3Via2Node_pos); };
   AnyRefNode LongissimusThoracisR11S3Via1NodeR = {sRel = .Scale(.Data.R12.Right.LongissimusThoracisR11S3Via1Node_pos); };
   AnyRefNode LongissimusThoracisR11S3Via1NodeL = {sRel = .Scale(.Data.R12.Left.LongissimusThoracisR11S3Via1Node_pos); };
-  
+
   AnyRefNode PsoasMajorT12NodeR = {sRel = .Scale(.Data.Thorax.Right.PsoasMajorT12Node_pos);};
   AnyRefNode PsoasMajorT12NodeL = {sRel = .Scale(.Data.Thorax.Left.PsoasMajorT12Node_pos);};
   AnyRefNode O_serratus_posterior_inferior_T12R = {sRel = .Scale(.Data.T12.O_serratus_posterior_inferior_pos); };
@@ -1305,6 +1326,7 @@ Segments.T12Seg = {
       .Scale(.Data.T12.T11T12JntNode_pos) + .Scale(.Data.T12.T12L1JntNode_pos)
     );
   };
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.T12.SupraSpinous_superior_points[0]);};
 
   Right = {
     //Rotatores
@@ -1463,7 +1485,7 @@ Segments.SternalBodySeg = {
           sRel = mean({
             .Right.points_generator.points[.Right.points_generator.amount - 1],
             .Left.points_generator.points[.Right.points_generator.amount - 1]}');
-        };   
+        };
       };
       CavityPoints Level10_Discretization28(data=....Data.unscaled.ModelParameters.ThoracicCavity.Level10, scale_fun=..Scale) = {
         Right.points_generator = {
@@ -1480,7 +1502,7 @@ Segments.SternalBodySeg = {
           sRel = mean({
             .Right.points_generator.points[4],
             .Left.points_generator.points[4]}');
-        };   
+        };
       };
 
     };
@@ -1684,7 +1706,7 @@ Segments.Left = {
         start = 0.08;
         end = 0.64;
       };
-    }; 
+    };
   };
   R8Seg = {
     CavityNodesThoracic ThoracicCavityNodes(
@@ -1704,7 +1726,7 @@ Segments.Left = {
         start = 0.08;
         end = 0.7;
       };
-    }; 
+    };
   };
   R7Seg = {
     CavityNodesThoracic ThoracicCavityNodes(

--- a/Body/AAUHuman/Trunk/SegmentsCervicalSpine.any
+++ b/Body/AAUHuman/Trunk/SegmentsCervicalSpine.any
@@ -832,7 +832,7 @@ AnySeg C7Seg = {
   AnyRefNode O_serratus_posterior_superior_1C7NodeL = {sRel = .Scale(.Data.Left.O_serratus_posterior_superior_1C7Node_pos); };
 
   AnyRefNode SemispinalisThoracisC7Spinous = {sRel = .Scale(.Data.SemispinalisThoracisC7Spinous_pos); };
-
+  AnyRefNode SpinousProcess = {sRel = .Scale(.Data.SpinousProcess);};
 
   Right = {
     //Iliocostalis Cervicis

--- a/Body/AAUHuman/Trunk/TrunkData1.1/CervicalNodes.any
+++ b/Body/AAUHuman/Trunk/TrunkData1.1/CervicalNodes.any
@@ -267,6 +267,7 @@ AnyFolder C7 = {
   AnyFloat MidNode_pos = {0.017, 0.471, 0.0};
   AnyFloat SuperiorEndplateAnteriorNode_pos = {0.030200, 0.475600, 0.000000};
   AnyFloat SuperiorEndplatePosteriorNode_pos = {0.017800, 0.480000, 0.000000};
+  AnyFloat SpinousProcess = {-0.036, 0.472, 0.0};
 
   AnyFolder Right = {
     AnyFloat IliocostalisCervicisR3C4Via1Node_pos    = {-0.0145, 0.496, 0.032};


### PR DESCRIPTION
This PR adds spinous process bony landmark nodes to every vertebra. 

The position is created from the data points also used for the ligaments. They are currently good for the lumbar region, but the data points needs to be adjusted for thoracic region, which will move bony landmarks introduced here a bit. See: [AB#2825](https://abtv-devops1/AnyBodyTech/be71f005-c830-46ca-9fb5-c92f0c92d6c0/_workitems/edit/2825)