### PR TITLE
chore: update 4.0 releasenotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ for more info about the abdominal model.
 
 It is possible to revert to the old buckle implementation with switch {bm_statement}`_CAVITY_MODEL_BUCKLE_`.
 
+#### New Hand Model
+
+A new hand model is introduced.
+More detail to come.
+
 #### Integrated Glasgow-Maastricht (GM) Foot Model
 
 The Glasgow-Maastricht (GM) foot model is now integrated into the AMMR.
@@ -77,6 +82,12 @@ and Thoracic model uses geometry-based inertia. The old models keep the standard
 inertia properties. The system also controls how mass is scaled when setting
 `Main.HumanModel.Anthropometrics.BodyMass`. It will distribute the mass to the different
 segments based on whether they are marked as being part of the distribution.
+
+### ➕ Added
+
+* New morphing tools:
+* New environment tools:
+* New Postural reference frames:
 
 ### 🩹 Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,92 +7,85 @@
 
 ## AMMR 4.0 beta
 
-:::{admonition} Default pelvis changed. 
-:class: warning
-The default pelvis morphology now comes from trunk pelvis. The topology remain unchanged as the leg model pelvis is morphed to match the Trunk. See [below how to control this behaviour](changes-to-default-pelvis-morphology).
-:::
+### Summary
 
-:::{admonition} Muscles locations restructured
-:class: warning
-Muscles elements are now grouped into folders representing the physiological muscles. 
-You can [enable backwards compatibility](changes-to-muscles-locations) by setting:
+AMMR 4.0 is a major release introducing several significant model improvements
+across the full body. The headline additions are a new **detailed thoracic model**
+with individual ribs and a two-part sternum, and a new **abdominal pressure model**
+with updated oblique, rectus, and transversus muscles — replacing the older buckle
+implementation. The **Glasgow-Maastricht (GM) foot model** is now fully integrated
+and becomes the default foot for the TLEM leg, bringing a richer muscle dataset in
+rigid, toe-flexion, and detailed 26-segment configurations. A new **whole-body
+inertia and mass-scaling system** based on `AnyInertia` subclasses provides more
+accurate mass distribution and geometry-based inertia for the new thoracic and
+abdominal models.
+
+Beyond new features, the **shoulder-arm model** received anatomical frame, scaling,
+and inertia updates, and the **default pelvis morphology** now comes from the trunk
+model. Muscle elements in the arm and TLEM2 leg have been regrouped into folders
+representing physiological muscles — backward compatibility switches are available
+for both changes during the transition period. The deprecated **TLEM 1 model** has
+been removed; TLEM 2.2 is now the only available leg model.
+
+### New Features
+
+#### New Detailed Thoracic Model
+
+A new detailed thoracic model was added. This model consists of the thoracic vertebral
+column and the ribcage, including individual ribs and a two-part sternum. The many
+segments interconnected by joints replicates the physiological connection and load
+transfer mechanisms.
+
+The detailed thoracic model can be enabled with the switch {bm_statement}`BM_TRUNK_THORACIC_MODEL`:
+
 ```AnyScriptDoc
-#define BM_COMPATIBILITY_MUSCLE_STRUCTURE ON
-```
-
-:::
-:::{admonition} Folder locations restructured
-:class: warning
-Many folders inside the Leg and Arm models have been renamed and/or moved to ensure a consistent BodyModel structure.
-You can [enable backwards compatibility](changes-to-bodymodel-folders) by setting:
-```AnyScriptDoc
-#define BM_COMPATIBILITY_BODYMODEL_STRUCTURE ON
-```
-:::
-
-:::{admonition} Default foot model changed. 
-:class: warning
-The default foot model for the TLEM leg has been switched to the rigid configuration of the
-{ref}`Glasgow-Maastricht (GM) foot model<GM Foot Model>`. See below [implications of this change](changes-to-default-foot-model). 
-You can revert to the TLEM foot model by setting:
-```AnyScriptDoc
-#define BM_FOOT_MODEL _FOOT_MODEL_LEG_FOOT_
-```
-:::
-
-**Fixed:**
-
-* Fixed the inclusion of the buckle segmental masses in the calculation of the TotalBodyMass variable.
-* Fixed the cervical spine axial rotation rhythm coefficients. The distribution between C2C1 and the rest of cervical spine was incorrect.
-* The BM statement BM_TRUNK_THORACIC_RHYTHM _RHYTHM_SOFT did not previously have any effect, this has been fixed
-
-**Added:**
-
-* A new detailed thoracic model was added. This model consists of the thoracic vertebral column and the
-  ribcage, including individual ribs and a two-part sternum. The many segments interconnected by joints
-  replicates the physiological connection and load transfer mechanisms.
-
-  The detailed thoracic model can be enabled with the switch {bm_statement}`BM_TRUNK_THORACIC_MODEL`: 
-
-  ```
-  #define BM_TRUNK_THORACIC_MODEL _THORACIC_MODEL_FLEXIBLE_
+#define BM_TRUNK_THORACIC_MODEL _THORACIC_MODEL_FLEXIBLE_
   ```
 
-  :::{note} The detailed thoracic model is not enabled by default. It adds many more segments to the body model so 
-  only use this new model if you need the added complexity. 
-  :::
+:::{note} The detailed thoracic model is not enabled by default. It adds many more segments to the body model so
+only use this new model if you need the added complexity.
+:::
 
-  The model is based on the work of Ignasiak, D (2016) and Shayestehpour (2021 and 2024). See the {ref}`documentation page <Ribcage and Thoracic Spine Model>` for more info. 
+The model is based on the work of Ignasiak, D (2016) and Shayestehpour (2021 and 2024). See the {ref}`documentation page <Ribcage and Thoracic Spine Model>` for more info.
 
-* A new abdominal model was added to replace the old 'buckle' model. 
-  It uses a new kinematic volume measure from AnyBody 7.5 to model the abdominal pressure 
-  and includes new oblique, rectus and transversus muscles. The new abdominal model is 
-  more robust and allows a bigger range of motion of the trunk. See the {ref}`documentation page <Abdominal Pressure Model>` 
-  for more info about the abdominal model. 
+#### New Abdominal Model
 
-  It is possible to revert to the old buckle implementation with switch {bm_statement}`_CAVITY_MODEL_BUCKLE_`. 
+A new abdominal model was added to replace the old 'buckle' model.
+It uses a new kinematic volume measure from AnyBody 7.5 to model the abdominal pressure
+and includes new oblique, rectus and transversus muscles. The new abdominal model is
+more robust and allows a bigger range of motion of the trunk. See the {ref}`documentation page <Abdominal Pressure Model>`
+for more info about the abdominal model.
 
-* The Glasgow-Maastricht (GM) foot model is now integrated into the AMMR. 
-  The GM foot has been morphed to the TLEM foot and uses the same reference system and ankle and subtalar joint 
-  parameters as the TLEM foot. The muscle parameters of the foot instead come from the GM foot. The GM foot models 
-  are available in multiple configurations: rigid foot (which is now the default foot model for the TLEM leg
-  in AMMR), toe flexion configuration (which has linked flexion extension degree of freedom for all toes), and the 
-  full-blown detailed foot model with 26 segments. The GM foot model is also accompanied by new switches, for 
-  example, {bm_statement}`BM_FOOT_MUSCLES_LEFT` to control the muscle behavior in GM foot model. 
-  See the {ref}`documentation page <GM Foot Model>` for more info.
+It is possible to revert to the old buckle implementation with switch {bm_statement}`_CAVITY_MODEL_BUCKLE_`.
 
-* A new system for handling mass and inertia calculation for segments in the
-  Trunk. Now we utilize the new inertia classes derived from `AnyInertia`. The
-  new Abdominal and Thoracic model uses geometry-based inertia. The old models
-  keep the standard mass and inertia properties. The system also controls how
-  mass is scaled when setting `Main.HumanModel.Anthropometrics.BodyMass`. It
-  will distribute the mass to the different segments based on whether they are
-  marked as being part of the distribution.
+#### Integrated Glasgow-Maastricht (GM) Foot Model
+
+The Glasgow-Maastricht (GM) foot model is now integrated into the AMMR.
+The GM foot has been morphed to the TLEM foot and uses the same reference system and ankle and subtalar joint
+parameters as the TLEM foot. The muscle parameters of the foot instead come from the GM foot. The GM foot models
+are available in multiple configurations: rigid foot (which is now the default foot model for the TLEM leg
+in AMMR), toe flexion configuration (which has linked flexion extension degree of freedom for all toes), and the
+full-blown detailed foot model with 26 segments. The GM foot model is also accompanied by new switches, for
+example, {bm_statement}`BM_FOOT_MUSCLES_LEFT` to control the muscle behavior in GM foot model.
+See the {ref}`documentation page <GM Foot Model>` for more info.
+
+#### New Fullbody Inertia and Mass-scaling calculations
+
+A new system for handling mass and inertia calculation for segments in the whole human
+model. Now we utilize the new inertia classes derived from `AnyInertia`. The new Abdominal
+and Thoracic model uses geometry-based inertia. The old models keep the standard mass and
+inertia properties. The system also controls how mass is scaled when setting
+`Main.HumanModel.Anthropometrics.BodyMass`. It will distribute the mass to the different
+segments based on whether they are marked as being part of the distribution.
+
+### 🩹 Fixed
 
 * The cervical model now has linear stiffness coefficients. These can be enabled with the switch {bm_statement}`BM_TRUNK_CERVICAL_DISC_STIFFNESS`:
-  ```
+  
+  ```AnyScriptDoc
   #define BM_TRUNK_CERVICAL_DISC_STIFFNESS _DISC_STIFFNESS_LINEAR_
   ```
+
   Only linear stiffness function is available for cervical discs currently.
 
 * New muscles are added in the neck region. These include iliocostalis cervicis, longus colli superior and inferior obliques, and additional fibers
@@ -103,36 +96,57 @@ You can revert to the TLEM foot model by setting:
 
 * The force plates now support slopped surface offsets.  This enables the force
   plate class template to calculate the COP on sloped offset surface. Like if
-  you added a sloped wedge on top of the force plate. 
+  you added a sloped wedge on top of the force plate.
 
 * Type 4 and type 2 now has the option to set a baseline offset to the measured
   force channels
   (`Plate.ForcePlate.BaselineOffset.Fx`/`Fy`/`Fz`/`Mx`/`My`/`Mz`). This can be
-  usefull if baseline correction needs to be done. 
+  usefull if baseline correction needs to be done.
 
-**Changed:**
+  * Fixed the inclusion of the buckle segmental masses in the calculation of the TotalBodyMass variable.
+
+  * Fixed the cervical spine axial rotation rhythm coefficients. The distribution between C2C1 and the rest of cervical spine was incorrect.
+  
+  * The BM statement BM_TRUNK_THORACIC_RHYTHM_RHYTHM_SOFT did not previously have any effect, this has been fixed
+
+### 🔧 Changed
 
 (changes-to-shoulder-arm model)=
+
 * {doc}`/body/shoulder_arm_model` has been updated in terms of anatomical frames, scaling, and mass properties:
-   * Anatomical frames are now explicitly defined using bony landmarks, replacing previous implicit definitions. The new definitions ensure consistency throughout the body: in a standing posture, the Y-axis points upward, the X-axis points forward, and the Z-axis points laterally (to the right). This update affects models with nodes referenced to the anatomical frame, such as MoCap models, which may require updated marker protocols. A migration guide is available.
-   * Scaling of the scapula and clavicle now uses the thorax trunk `ScalingNode`. While this was previously the case, the new implementation is more precise. The conoid ligament length is also scaled more accurately, resulting in improved initial positioning of the clavicle and scapula across all scaling scenarios.
-   * Inertia calculations are now based on approximate skin surfaces and bone geometries, providing greater accuracy.
-   * Postural frames have been introduced in the shoulder girdle to enhance anatomical representation.
+  * Anatomical frames are now explicitly defined using bony landmarks, replacing previous implicit definitions. The new definitions ensure consistency throughout the body: in a standing posture, the Y-axis points upward, the X-axis points forward,and the Z-axis points laterally (to the right). This update affects models with nodes referenced to the anatomical frame, such as MoCap models, which may require updated marker protocols. A migration guide is available.
+  * Scaling of the scapula and clavicle now uses the thorax trunk `ScalingNode`. While this was previously the case, the new implementation is more precise. The conoid ligament length is also scaled more accurately, resulting in improved initialpositioning of the clavicle and scapula across all scaling scenarios.
+  * Inertia calculations are now based on approximate skin surfaces and bone geometries, providing greater accuracy.
+  * Postural frames have been introduced in the shoulder girdle to enhance anatomical representation.
 
-
+:::{admonition} Default pelvis changed.
+:class: warning
+The default pelvis morphology now comes from trunk pelvis. The topology remain unchanged as the leg model pelvis is morphed to match the Trunk. See [below how to control this behaviour](changes-to-default-pelvis-morphology).
+:::
 
 (changes-to-default-pelvis-morphology)=
 
 * The default pelvis morphology is now the one from the trunk model, as opposed to the pelvis belonging
   to whatever leg model has been selected. This was done to get a consistent
-  trunk model and considering all the recent improvements to the trunk. This option can be controlled with: 
+  trunk model and considering all the recent improvements to the trunk. This option can be controlled with:
 
-  ```
+  ```AnyScriptDoc
   #define BM_LEG_TRUNK_INTERFACE _MORPH_LEG_TO_TRUNK_
   ```
 
   In practice, this means that the morphology of the leg pelvis is morphed to match the Trunk pelvis.
   Using `_MORPH_TRUNK_TO_LEG_` instead will revert to the old behaviour.
+
+:::{admonition} Muscles locations restructured
+:class: warning
+Muscles elements are now grouped into folders representing the physiological muscles.
+You can [enable backwards compatibility](changes-to-muscles-locations) by setting:
+
+```AnyScriptDoc
+#define BM_COMPATIBILITY_MUSCLE_STRUCTURE ON
+```
+
+:::
 
 (changes-to-muscles-locations)=
 
@@ -146,19 +160,42 @@ You can revert to the TLEM foot model by setting:
   they are defined in AMMR 3.x. This BM switch will be deprecated in a future AMMR
   version.
 
+:::{admonition} Folder locations restructured
+:class: warning
+Many folders inside the Leg and Arm models have been renamed and/or moved to ensure a consistent BodyModel structure.
+You can [enable backwards compatibility](changes-to-bodymodel-folders) by setting:
+
+```AnyScriptDoc
+#define BM_COMPATIBILITY_BODYMODEL_STRUCTURE ON
+```
+
+:::
+
 (changes-to-bodymodel-folders)=
 
 * Many of the key folders inside the Leg and Arm models have been renamed to create a unified structure across the full BodyModel. To bring back the old structure we have temporarily included a backward compatibility switch `BM_COMPATIBILITY_BODYMODEL_STRUCTURE` To ensure a smooth transition.
 
+:::{admonition} Default foot model changed.
+:class: warning
+The default foot model for the TLEM leg has been switched to the rigid configuration of the
+{ref}`Glasgow-Maastricht (GM) foot model<GM Foot Model>`. See below [implications of this change](changes-to-default-foot-model).
+You can revert to the TLEM foot model by setting:
+
+```AnyScriptDoc
+#define BM_FOOT_MODEL _FOOT_MODEL_LEG_FOOT_
+```
+
+:::
+
 (changes-to-default-foot-model)=
 
-* The default foot model for the TLEM leg is now changed to the rigid variant of the 
-  {ref}`GM foot model <GM Foot Model>` instead of the default TLEM foot. This is done to 
+* The default foot model for the TLEM leg is now changed to the rigid variant of the
+  {ref}`GM foot model <GM Foot Model>` instead of the default TLEM foot. This is done to
   use the detailed dataset available in the GM foot model. This change might
-  lead to `Unresolved object` errors in objects referring to the foot model. See this 
-  {ref}`guide<Foot Unresolved Objects>` on how to resolve these errors. Corresponding to 
+  lead to `Unresolved object` errors in objects referring to the foot model. See this
+  {ref}`guide<Foot Unresolved Objects>` on how to resolve these errors. Corresponding to
   this change, the switch `_FOOT_MODEL_DEFAULT_` is now deprecated. The TLEM foot model
-  can be selected with: 
+  can be selected with:
 
   ```AnyScriptDoc
   #define BM_FOOT_MODEL _FOOT_MODEL_LEG_FOOT_
@@ -178,19 +215,20 @@ You can revert to the TLEM foot model by setting:
   of gastrocnemius and soleus muscles. The change causes a minor shift in the joint axis, but it should 
   not significantly impact results.
 
-
 (changes-to-mandible-model)=
 
-*  The NormalMandible_AAU model has been updated to use more cleaned-up surfaces for contact in FDK models. This helps FDK models to converge. Most importantly the backside of the contact surfaces has been removed.
+* The NormalMandible_AAU model has been updated to use more cleaned-up surfaces for contact in FDK models. This helps FDK models to converge. Most importantly the backside of the contact surfaces has been removed.
 
-### Removed:
+### ❌ Removed
 
-* The deprecated TLEM 1 model has been removed from the AMMR. The TLEM 2.2 model is now the only TLEM based model 
-  available in the AMMR. It is activated by default or by setting: 
+* The deprecated TLEM 1 model has been removed from the AMMR. The TLEM 2.2 model is now the only TLEM based model
+  available in the AMMR. It is activated by default or by setting:
+
   ``` AnyScriptDoc
   #define BM_LEG_MODEL _LEG_MODEL_TLEM_
   ```
-* Remove a number of previously deprecated `BM_XXX` switches and constants. 
+
+* Remove a number of previously deprecated `BM_XXX` switches and constants.
 
 (ammr-3-2-1-changelog)=
 ## AMMR 3.2.1 (2026-05-21)


### PR DESCRIPTION
Update the releasenotes section for 4.0 for easier navigation in the TOC and for readability