### PR TITLE
fix: bug fix directions of scaling factors for hand in XYZ scaling

### DIFF
--- a/Body/AAUHuman/Scaling/ScalingXYZMassFat.any
+++ b/Body/AAUHuman/Scaling/ScalingXYZMassFat.any
@@ -190,9 +190,9 @@ defined in a special file that contains segmental scaling vectors.
 
         AnyFunTransform3DLin ScaleFunction = {
           ScaleMat ={
-            {.WidthScale,0.0,0.0},   // mediolateral width
-            {0.0, .LengthScale, 0.0},  // long axis
-            {0.0,0.0,.DepthScale }    // anteroposterior depth
+            {.DepthScale, 0.0, 0.0},     // hand thickness
+            {0.0, .LengthScale, 0.0},    // fingers aligned axis 
+            {0.0, 0.0, .WidthScale},     // mediolateral width
           };
           Offset = {0,0,0};
         };
@@ -338,9 +338,9 @@ defined in a special file that contains segmental scaling vectors.
 
         AnyFunTransform3DLin ScaleFunction = {
           ScaleMat ={
-            {.LengthScale, 0.0, 0.0},   // fingers aligned axis
-            {0.0, .WidthScale, 0.0},    // mediolateral width
-            {0.0, 0.0, .DepthScale}     // hand thickness
+            {.DepthScale, 0.0, 0.0},     // hand thickness
+            {0.0, .LengthScale, 0.0},    // fingers aligned axis 
+            {0.0, 0.0, .WidthScale},     // mediolateral width
           };
           Offset = {0,0,0};
         };


### PR DESCRIPTION
The directions of scaling factors for hand in XYZ scaling were incorrect. They are now fixed.

Changelog is not updated.