### PR TITLE
fix: avoid drawing the sacrum inside the pelvis seg

### DIFF
--- a/Body/AAUHuman/LegTLEM/Seg.any
+++ b/Body/AAUHuman/LegTLEM/Seg.any
@@ -2046,21 +2046,13 @@ PelvisSeg =
       };
 
       #if (BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGANDTRUNKPELVIS_)
-      AnyDrawSurf Drw_LegSacrum =
-      #else
-      AnyDrawSurf DrwSacrum =
-      #endif
-      {
+      AnyDrawSurf Drw_LegSacrum = {
         FileName ??= ..STL.FilenameSacrum;
         Opacity ??=  Main.DrawSettings.BonesOpacity.Pelvis;
         RGB ??= ...ColorRef.Segments;
         AnyFunTransform3D &Scale = .AnatomicalFrameTrunk.Scale_Leg_Pelvis ;
       };
-
       #endif
       #endif
-
-
+      #endif
 }; // End Pelvis
-
-

--- a/Body/AAUHuman/Trunk/PelvisSeg.any
+++ b/Body/AAUHuman/Trunk/PelvisSeg.any
@@ -329,21 +329,18 @@ AnySeg PelvisSeg = {
   };
 
   #if (BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGANDTRUNKPELVIS_)
-  AnyDrawSurf Drw_TrunkSacrum =
-  #else
-  AnyDrawSurf DrwSacrum =
+    AnyDrawSurf Drw_TrunkSacrum = {
+      FileName = ...Data.unscaled.STL.FilenameSacrumSeg           ;
+      #if (BM_LEG_LEFT == OFF) & (BM_LEG_RIGHT == OFF)
+        Opacity ??= Main.DrawSettings.BonesOpacity.Pelvis;
+        RGB = ...ColorRef.Segments;
+      #else
+        Opacity ??= Main.DrawSettings.BonesOpacity.Pelvis * 0.5;
+        RGB = ...ColorRef.Segments;
+      #endif
+      AnyFunTransform3D &Scale = .Scale;
+    };
   #endif
-  {
-    FileName = ...Data.unscaled.STL.FilenameSacrumSeg           ;
-    #if (BM_LEG_LEFT == OFF) & (BM_LEG_RIGHT == OFF)
-      Opacity ??= Main.DrawSettings.BonesOpacity.Pelvis;
-      RGB = ...ColorRef.Segments;
-    #else
-      Opacity ??= Main.DrawSettings.BonesOpacity.Pelvis * 0.5;
-      RGB = ...ColorRef.Segments;
-    #endif
-    AnyFunTransform3D &Scale = .Scale;
-  };
 
   #endif
 

--- a/Body/AAUHuman/Trunk/SegmentsLumbar.any
+++ b/Body/AAUHuman/Trunk/SegmentsLumbar.any
@@ -46,10 +46,10 @@ AnySeg SacrumSeg = {
         enableMassCorrection = Off;
       };
       AnySurfSTL surface = {
-        FileName = ...PelvisSeg.DrwSacrum.FileName;
+        FileName = ..DrwSacrum.FileName;
         AnyFunTransform3D &scale = ..Scale;
         viewSurface.RGB = {0,0,1};
-        ScaleXYZ = ...PelvisSeg.DrwSacrum.ScaleXYZ;
+        ScaleXYZ = ..DrwSacrum.ScaleXYZ;
       };
     };
   #else

--- a/Body/AAUHuman/Trunk/SegmentsLumbar.any
+++ b/Body/AAUHuman/Trunk/SegmentsLumbar.any
@@ -46,10 +46,9 @@ AnySeg SacrumSeg = {
         enableMassCorrection = Off;
       };
       AnySurfSTL surface = {
-        FileName = ..DrwSacrum.FileName;
+        FileName = ....Data.unscaled.STL.FilenameSacrumSeg;
         AnyFunTransform3D &scale = ..Scale;
-        viewSurface.RGB = {0,0,1};
-        ScaleXYZ = ..DrwSacrum.ScaleXYZ;
+
       };
     };
   #else
@@ -213,27 +212,18 @@ AnySeg SacrumSeg = {
 
   AnyRefNode LongissimusThoracisR12S3ViaNodeR = {sRel = .Scale(.Data.Right.LongissimusThoracisR12S3ViaNode_pos);};
   AnyRefNode LongissimusThoracisR12S3ViaNodeL = {sRel = .Scale(.Data.Left.LongissimusThoracisR12S3ViaNode_pos);};
-}; // SacrumSeg
 
-
-// -------- Drawing object section (pelvis&sacrum)--------
-#if (! BM_LEG_MODEL_IS_TLEM ) | (BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGANDTRUNKPELVIS_)
-  SacrumSeg = {
-    #if (BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGANDTRUNKPELVIS_)
-    DrwSacrumForTrunk.Opacity = Main.DrawSettings.BonesOpacity.Sacrum*0.5;
-    AnyDrawSurf DrwSacrumForTrunk =
-    #else
-    DrwSacrum.Opacity = Main.DrawSettings.BonesOpacity.Sacrum;
-    AnyDrawSurf DrwSacrum =
-    #endif
-    {
+    // -------- Drawing object section sacrum--------
+    #if BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGPELVIS_ONLY_
+    AnyDrawSurf DrwSacrum = {
+      Opacity = Main.DrawSettings.BonesOpacity.Sacrum;
       FileName = ...Data.unscaled.STL.FilenameSacrumSeg;
       RGB = ...ColorRef.Segments;
       AnyFunTransform3D &Scale =.Scale;
     };
+    // -------- End of drawing section sacrum--------
+    #endif
   }; // SacrumSeg
-#endif
-// -------- End of drawing section (pelvis&sacrum)--------
 
 
 AnySeg L5Seg = {

--- a/Tests/BM combinations/test_pelvis_sacrum_drawing.any
+++ b/Tests/BM combinations/test_pelvis_sacrum_drawing.any
@@ -1,0 +1,46 @@
+//define = (
+//  [
+//    {'BM_PELVIS_DISPLAY': '_PELVIS_DISPLAY_NONE_'},
+//    {'BM_PELVIS_DISPLAY': '_PELVIS_DISPLAY_LEGPELVIS_ONLY_'},
+//    {'BM_PELVIS_DISPLAY': '_PELVIS_DISPLAY_LEGANDTRUNKPELVIS_'},
+//  ]
+//)
+
+#ifndef BM_PELVIS_DISPLAY
+  #define BM_PELVIS_DISPLAY 2
+#endif
+
+#include "libdef.any"
+
+Main =
+{
+  // #path HTML_DOC "<AMMR_PATH_DOC>/bm_config/index.html"
+  #include "<ANYBODY_PATH_BODY>\HumanModel.any"
+
+  AnyOperationDummy RunApplication = {};
+
+  // Tests
+  AnyObjectPtr pelvis = &Main.HumanModel.BodyModel.Trunk.Segments.PelvisSeg;
+  AnyObjectPtr sacrum = &Main.HumanModel.BodyModel.Trunk.Segments.SacrumSeg;
+
+  AnyObjectPtr pelvis_drawObjects = ObjSearch(pelvis, "*", "AnyDrawSurf");
+  AnyObjectPtr sacrum_drawObjects = ObjSearch(sacrum, "*", "AnyDrawSurf");
+
+  #if BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_NONE_
+    AnyInt test_no_drawings_pelvis = expect(eqfun(NumElemOf(pelvis_drawObjects), 0), "pelvis has draw objects when drawing is turned off!");
+    AnyInt test_no_drawings_sacrum = expect(eqfun(NumElemOf(sacrum_drawObjects), 0), "sacrum has draw objects when drawing is turned off!");
+  #endif
+
+  #if BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGPELVIS_ONLY_
+    AnyInt test_no_drawings_pelvis = expect(eqfun(NumElemOf(pelvis_drawObjects), 1), "pelvis has a wrong number of draw objects!");
+    AnyInt test_no_drawings_sacrum = expect(eqfun(NumElemOf(sacrum_drawObjects), 1), "sacrum has a wrong number of draw objects!");
+  #endif
+  
+  #if BM_PELVIS_DISPLAY == _PELVIS_DISPLAY_LEGANDTRUNKPELVIS_
+    /// We currently put pelvis and sacrum drawnings for both trunk and leg data sets on the pelvis segement.
+    /// this was done prior to defining the sacrum as a real segment.
+    /// we could consider to move the sacrum drawings into the sacrum segment for consistency
+    AnyInt test_no_drawings_pelvis = expect(eqfun(NumElemOf(pelvis_drawObjects), 4), "pelvis has a wrong number of draw objects!");
+    AnyInt test_no_drawings_sacrum = expect(eqfun(NumElemOf(sacrum_drawObjects), 0), "sacrum has draw objects but all are expected on pelvis!");
+  #endif
+};


### PR DESCRIPTION
The sacrum was drawn two times, once inside the pelvis seg (legacy) and once inside the sacrum seg. 
It only appeared with the flexible thorax on. 

Now the drawing inside the pelvis is removed.